### PR TITLE
Add comprehensive unit tests for all ViewModels

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/meneses/budgethunter/commons/data/FileManager.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/meneses/budgethunter/commons/data/FileManager.android.kt
@@ -7,9 +7,9 @@ import java.io.IOException
 /**
  * Android implementation of FileManager for budget entry invoice handling.
  */
-actual class FileManager {
+actual class FileManager : IFileManager {
 
-    actual fun saveFile(fileData: FileData): String {
+    override fun saveFile(fileData: FileData): String {
         return saveFile(fileData.data, fileData.directory, fileData.filename)
     }
 
@@ -23,7 +23,7 @@ actual class FileManager {
         return file.absolutePath
     }
 
-    actual fun deleteFile(filePath: String): Boolean {
+    override fun deleteFile(filePath: String): Boolean {
         return try {
             File(filePath).delete()
         } catch (_: IOException) {
@@ -31,11 +31,11 @@ actual class FileManager {
         }
     }
 
-    actual fun createUri(filePath: String): String {
+    override fun createUri(filePath: String): String {
         return File(filePath).toUri().toString()
     }
 
-    actual fun fileExists(filePath: String): Boolean {
+    override fun fileExists(filePath: String): Boolean {
         return File(filePath).exists()
     }
 }

--- a/composeApp/src/androidMain/kotlin/com/meneses/budgethunter/commons/platform/AppUpdateManager.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/meneses/budgethunter/commons/platform/AppUpdateManager.android.kt
@@ -17,7 +17,7 @@ interface AppUpdateLauncherDelegate {
     )
 }
 
-actual class AppUpdateManager(
+class AppUpdateManager(
     private val context: Context
 ) : IAppUpdateManager {
 

--- a/composeApp/src/androidMain/kotlin/com/meneses/budgethunter/commons/platform/AppUpdateManager.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/meneses/budgethunter/commons/platform/AppUpdateManager.android.kt
@@ -17,7 +17,7 @@ interface AppUpdateLauncherDelegate {
     )
 }
 
-class AppUpdateManager(
+actual class AppUpdateManager(
     private val context: Context
 ) : IAppUpdateManager {
 

--- a/composeApp/src/androidMain/kotlin/com/meneses/budgethunter/commons/platform/AppUpdateManager.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/meneses/budgethunter/commons/platform/AppUpdateManager.android.kt
@@ -19,7 +19,7 @@ interface AppUpdateLauncherDelegate {
 
 actual class AppUpdateManager(
     private val context: Context
-) {
+) : IAppUpdateManager {
 
     private var googleAppUpdateManager: GoogleAppUpdateManager? = null
     private var launcherDelegate: AppUpdateLauncherDelegate? = null
@@ -39,7 +39,7 @@ actual class AppUpdateManager(
         this.launcherDelegate = delegate
     }
 
-    actual fun checkForUpdates(onResult: (AppUpdateResult) -> Unit) {
+    override fun checkForUpdates(onResult: (AppUpdateResult) -> Unit) {
         currentCallback = onResult
         googleAppUpdateManager = AppUpdateManagerFactory.create(context)
         val updateInfoTask = googleAppUpdateManager!!.appUpdateInfo

--- a/composeApp/src/androidMain/kotlin/com/meneses/budgethunter/commons/platform/PermissionsManager.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/meneses/budgethunter/commons/platform/PermissionsManager.android.kt
@@ -14,7 +14,7 @@ interface PermissionsLauncherDelegate {
     fun shouldShowSMSPermissionRationale(): Boolean
 }
 
-actual class PermissionsManager(private val context: Context) : IPermissionsManager {
+class PermissionsManager(private val context: Context) : IPermissionsManager {
 
     private var launcherDelegate: PermissionsLauncherDelegate? = null
     private var permissionResultCallback: ((Boolean) -> Unit)? = null

--- a/composeApp/src/androidMain/kotlin/com/meneses/budgethunter/commons/platform/PermissionsManager.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/meneses/budgethunter/commons/platform/PermissionsManager.android.kt
@@ -14,7 +14,7 @@ interface PermissionsLauncherDelegate {
     fun shouldShowSMSPermissionRationale(): Boolean
 }
 
-class PermissionsManager(private val context: Context) : IPermissionsManager {
+actual class PermissionsManager(private val context: Context) : IPermissionsManager {
 
     private var launcherDelegate: PermissionsLauncherDelegate? = null
     private var permissionResultCallback: ((Boolean) -> Unit)? = null

--- a/composeApp/src/androidMain/kotlin/com/meneses/budgethunter/commons/platform/PermissionsManager.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/meneses/budgethunter/commons/platform/PermissionsManager.android.kt
@@ -14,7 +14,7 @@ interface PermissionsLauncherDelegate {
     fun shouldShowSMSPermissionRationale(): Boolean
 }
 
-actual class PermissionsManager(private val context: Context) {
+actual class PermissionsManager(private val context: Context) : IPermissionsManager {
 
     private var launcherDelegate: PermissionsLauncherDelegate? = null
     private var permissionResultCallback: ((Boolean) -> Unit)? = null
@@ -23,11 +23,11 @@ actual class PermissionsManager(private val context: Context) {
         this.launcherDelegate = delegate
     }
 
-    actual fun shouldShowSMSPermissionRationale(): Boolean {
+    override fun shouldShowSMSPermissionRationale(): Boolean {
         return launcherDelegate?.shouldShowSMSPermissionRationale() ?: false
     }
 
-    actual fun hasSmsPermission(): Boolean {
+    override fun hasSmsPermission(): Boolean {
         val receiveSmsGranted = ContextCompat
             .checkSelfPermission(context, Manifest.permission.RECEIVE_SMS) ==
             PackageManager.PERMISSION_GRANTED
@@ -39,7 +39,7 @@ actual class PermissionsManager(private val context: Context) {
         return receiveSmsGranted && readSmsGranted
     }
 
-    actual fun requestSmsPermissions(callback: (granted: Boolean) -> Unit) {
+    override fun requestSmsPermissions(callback: (granted: Boolean) -> Unit) {
         permissionResultCallback = callback
         val permissions = mutableListOf(Manifest.permission.RECEIVE_SMS, Manifest.permission.READ_SMS)
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
@@ -48,7 +48,7 @@ actual class PermissionsManager(private val context: Context) {
         launcherDelegate?.launchPermissionsRequest(permissions.toTypedArray())
     }
 
-    actual fun openAppSettings() {
+    override fun openAppSettings() {
         val intent = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
             data = Uri.fromParts("package", context.packageName, null)
             flags = Intent.FLAG_ACTIVITY_NEW_TASK

--- a/composeApp/src/androidMain/kotlin/com/meneses/budgethunter/di/PlatformModule.kt
+++ b/composeApp/src/androidMain/kotlin/com/meneses/budgethunter/di/PlatformModule.kt
@@ -32,6 +32,7 @@ import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.serialization.kotlinx.json.json
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.serialization.json.Json
+import org.koin.core.module.dsl.bind
 import org.koin.core.qualifier.named
 import org.koin.dsl.module
 

--- a/composeApp/src/androidMain/kotlin/com/meneses/budgethunter/di/PlatformModule.kt
+++ b/composeApp/src/androidMain/kotlin/com/meneses/budgethunter/di/PlatformModule.kt
@@ -32,7 +32,6 @@ import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.serialization.kotlinx.json.json
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.serialization.json.Json
-import org.koin.core.module.dsl.bind
 import org.koin.core.qualifier.named
 import org.koin.dsl.module
 
@@ -50,11 +49,18 @@ val androidPlatformModule = module {
     }
 
     // Platform-specific managers
-    single<FileManager> { FileManager() } bind IFileManager::class
+    single<FileManager> { FileManager() }
+    single<IFileManager> { get<FileManager>() }
+
     single<CameraManager> { AndroidCameraManager(get<Context>()) }
     single<FilePickerManager> { AndroidFilePickerManager(get<Context>()) }
-    single<PermissionsManager> { PermissionsManager(get<Context>()) } bind IPermissionsManager::class
-    single<AppUpdateManager> { AppUpdateManager(get<Context>()) } bind IAppUpdateManager::class
+
+    single<PermissionsManager> { PermissionsManager(get<Context>()) }
+    single<IPermissionsManager> { get<PermissionsManager>() }
+
+    single<AppUpdateManager> { AppUpdateManager(get<Context>()) }
+    single<IAppUpdateManager> { get<AppUpdateManager>() }
+
     single<NotificationManager> { AndroidNotificationManager(get<Context>()) }
     single<ShareManager> { AndroidShareManager(get<Context>()) }
 

--- a/composeApp/src/androidMain/kotlin/com/meneses/budgethunter/di/PlatformModule.kt
+++ b/composeApp/src/androidMain/kotlin/com/meneses/budgethunter/di/PlatformModule.kt
@@ -11,6 +11,7 @@ import com.meneses.budgethunter.budgetEntry.domain.AIImageProcessor
 import com.meneses.budgethunter.budgetEntry.domain.AndroidAIImageProcessor
 import com.meneses.budgethunter.commons.data.DatabaseFactory
 import com.meneses.budgethunter.commons.data.FileManager
+import com.meneses.budgethunter.commons.data.IFileManager
 import com.meneses.budgethunter.commons.data.createDatabase
 import com.meneses.budgethunter.commons.platform.AndroidCameraManager
 import com.meneses.budgethunter.commons.platform.AndroidFilePickerManager
@@ -19,6 +20,8 @@ import com.meneses.budgethunter.commons.platform.AndroidShareManager
 import com.meneses.budgethunter.commons.platform.AppUpdateManager
 import com.meneses.budgethunter.commons.platform.CameraManager
 import com.meneses.budgethunter.commons.platform.FilePickerManager
+import com.meneses.budgethunter.commons.platform.IAppUpdateManager
+import com.meneses.budgethunter.commons.platform.IPermissionsManager
 import com.meneses.budgethunter.commons.platform.NotificationManager
 import com.meneses.budgethunter.commons.platform.PermissionsManager
 import com.meneses.budgethunter.commons.platform.ShareManager
@@ -46,11 +49,11 @@ val androidPlatformModule = module {
     }
 
     // Platform-specific managers
-    single<FileManager> { FileManager() }
+    single<FileManager> { FileManager() } bind IFileManager::class
     single<CameraManager> { AndroidCameraManager(get<Context>()) }
     single<FilePickerManager> { AndroidFilePickerManager(get<Context>()) }
-    single<PermissionsManager> { PermissionsManager(get<Context>()) }
-    single<AppUpdateManager> { AppUpdateManager(get<Context>()) }
+    single<PermissionsManager> { PermissionsManager(get<Context>()) } bind IPermissionsManager::class
+    single<AppUpdateManager> { AppUpdateManager(get<Context>()) } bind IAppUpdateManager::class
     single<NotificationManager> { AndroidNotificationManager(get<Context>()) }
     single<ShareManager> { AndroidShareManager(get<Context>()) }
 

--- a/composeApp/src/commonMain/kotlin/com/meneses/budgethunter/budgetDetail/BudgetDetailViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/meneses/budgethunter/budgetDetail/BudgetDetailViewModel.kt
@@ -4,7 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.meneses.budgethunter.budgetDetail.application.BudgetDetailEvent
 import com.meneses.budgethunter.budgetDetail.application.BudgetDetailState
-import com.meneses.budgethunter.budgetDetail.data.BudgetDetailRepository
+import com.meneses.budgethunter.budgetDetail.data.IBudgetDetailRepository
 import com.meneses.budgethunter.budgetEntry.domain.BudgetEntry
 import com.meneses.budgethunter.budgetEntry.domain.BudgetEntryFilter
 import com.meneses.budgethunter.budgetList.domain.Budget
@@ -14,7 +14,7 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
 class BudgetDetailViewModel(
-    private val budgetDetailRepository: BudgetDetailRepository
+    private val budgetDetailRepository: IBudgetDetailRepository
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(BudgetDetailState())

--- a/composeApp/src/commonMain/kotlin/com/meneses/budgethunter/budgetDetail/data/IBudgetDetailRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/meneses/budgethunter/budgetDetail/data/IBudgetDetailRepository.kt
@@ -1,0 +1,14 @@
+package com.meneses.budgethunter.budgetDetail.data
+
+import com.meneses.budgethunter.budgetDetail.domain.BudgetDetail
+import com.meneses.budgethunter.budgetEntry.domain.BudgetEntryFilter
+import kotlinx.coroutines.flow.Flow
+
+interface IBudgetDetailRepository {
+    suspend fun getCachedDetail(): BudgetDetail
+    fun getBudgetDetailById(budgetId: Int): Flow<BudgetDetail>
+    suspend fun getAllFilteredBy(filter: BudgetEntryFilter): BudgetDetail
+    suspend fun updateBudgetAmount(amount: Double)
+    suspend fun deleteBudget(budgetId: Int)
+    suspend fun deleteEntriesByIds(ids: List<Int>)
+}

--- a/composeApp/src/commonMain/kotlin/com/meneses/budgethunter/budgetEntry/BudgetEntryViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/meneses/budgethunter/budgetEntry/BudgetEntryViewModel.kt
@@ -4,12 +4,12 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.meneses.budgethunter.budgetEntry.application.BudgetEntryEvent
 import com.meneses.budgethunter.budgetEntry.application.BudgetEntryState
-import com.meneses.budgethunter.budgetEntry.application.CreateBudgetEntryFromImageUseCase
-import com.meneses.budgethunter.budgetEntry.data.BudgetEntryRepository
+import com.meneses.budgethunter.budgetEntry.application.ICreateBudgetEntryFromImageUseCase
+import com.meneses.budgethunter.budgetEntry.data.IBudgetEntryRepository
 import com.meneses.budgethunter.budgetEntry.domain.BudgetEntry
-import com.meneses.budgethunter.commons.application.ValidateFilePathUseCase
-import com.meneses.budgethunter.commons.data.FileManager
-import com.meneses.budgethunter.commons.data.PreferencesManager
+import com.meneses.budgethunter.commons.application.IValidateFilePathUseCase
+import com.meneses.budgethunter.commons.data.IFileManager
+import com.meneses.budgethunter.commons.data.IPreferencesManager
 import com.meneses.budgethunter.commons.platform.CameraManager
 import com.meneses.budgethunter.commons.platform.FilePickerManager
 import com.meneses.budgethunter.commons.platform.NotificationManager
@@ -26,11 +26,11 @@ import kotlinx.coroutines.launch
  * while being cross-platform compatible.
  */
 class BudgetEntryViewModel(
-    private val budgetEntryRepository: BudgetEntryRepository,
-    private val createBudgetEntryFromImageUseCase: CreateBudgetEntryFromImageUseCase,
-    private val validateFilePathUseCase: ValidateFilePathUseCase,
-    private val preferencesManager: PreferencesManager,
-    private val fileManager: FileManager,
+    private val budgetEntryRepository: IBudgetEntryRepository,
+    private val createBudgetEntryFromImageUseCase: ICreateBudgetEntryFromImageUseCase,
+    private val validateFilePathUseCase: IValidateFilePathUseCase,
+    private val preferencesManager: IPreferencesManager,
+    private val fileManager: IFileManager,
     private val cameraManager: CameraManager,
     private val filePickerManager: FilePickerManager,
     private val shareManager: ShareManager,

--- a/composeApp/src/commonMain/kotlin/com/meneses/budgethunter/budgetEntry/application/CreateBudgetEntryFromImageUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/com/meneses/budgethunter/budgetEntry/application/CreateBudgetEntryFromImageUseCase.kt
@@ -17,7 +17,7 @@ import kotlinx.datetime.toLocalDateTime
 class CreateBudgetEntryFromImageUseCase(
     private val aiImageProcessor: AIImageProcessor,
     private val ioDispatcher: CoroutineDispatcher
-) {
+) : ICreateBudgetEntryFromImageUseCase {
 
     /**
      * AI prompt preserved from the original Android implementation.
@@ -37,7 +37,7 @@ class CreateBudgetEntryFromImageUseCase(
 
         or return an empty response if the image is not an invoice, receipt or bill"""
 
-    suspend fun execute(
+    override suspend fun execute(
         imageUri: String,
         budgetEntry: BudgetEntry
     ): BudgetEntry = withContext(ioDispatcher) {

--- a/composeApp/src/commonMain/kotlin/com/meneses/budgethunter/budgetEntry/application/ICreateBudgetEntryFromImageUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/com/meneses/budgethunter/budgetEntry/application/ICreateBudgetEntryFromImageUseCase.kt
@@ -1,0 +1,7 @@
+package com.meneses.budgethunter.budgetEntry.application
+
+import com.meneses.budgethunter.budgetEntry.domain.BudgetEntry
+
+interface ICreateBudgetEntryFromImageUseCase {
+    suspend fun execute(imageUri: String, budgetEntry: BudgetEntry): BudgetEntry
+}

--- a/composeApp/src/commonMain/kotlin/com/meneses/budgethunter/budgetEntry/data/BudgetEntryRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/meneses/budgethunter/budgetEntry/data/BudgetEntryRepository.kt
@@ -8,15 +8,15 @@ import kotlinx.coroutines.withContext
 class BudgetEntryRepository(
     private val localDataSource: BudgetEntryLocalDataSource,
     private val ioDispatcher: CoroutineDispatcher
-) {
-    fun getAllByBudgetId(budgetId: Long) =
+) : IBudgetEntryRepository {
+    override fun getAllByBudgetId(budgetId: Long) =
         localDataSource.selectAllByBudgetId(budgetId)
 
-    suspend fun create(budgetEntry: BudgetEntry) = withContext(ioDispatcher) {
+    override suspend fun create(budgetEntry: BudgetEntry) = withContext(ioDispatcher) {
         localDataSource.create(budgetEntry)
     }
 
-    suspend fun update(budgetEntry: BudgetEntry) = withContext(ioDispatcher) {
+    override suspend fun update(budgetEntry: BudgetEntry) = withContext(ioDispatcher) {
         localDataSource.update(budgetEntry)
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/meneses/budgethunter/budgetEntry/data/IBudgetEntryRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/meneses/budgethunter/budgetEntry/data/IBudgetEntryRepository.kt
@@ -1,0 +1,10 @@
+package com.meneses.budgethunter.budgetEntry.data
+
+import com.meneses.budgethunter.budgetEntry.domain.BudgetEntry
+import kotlinx.coroutines.flow.Flow
+
+interface IBudgetEntryRepository {
+    fun getAllByBudgetId(budgetId: Long): Flow<List<BudgetEntry>>
+    suspend fun create(budgetEntry: BudgetEntry)
+    suspend fun update(budgetEntry: BudgetEntry)
+}

--- a/composeApp/src/commonMain/kotlin/com/meneses/budgethunter/budgetList/BudgetListViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/meneses/budgethunter/budgetList/BudgetListViewModel.kt
@@ -4,9 +4,9 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.meneses.budgethunter.budgetList.application.BudgetListEvent
 import com.meneses.budgethunter.budgetList.application.BudgetListState
-import com.meneses.budgethunter.budgetList.application.DeleteBudgetUseCase
-import com.meneses.budgethunter.budgetList.application.DuplicateBudgetUseCase
-import com.meneses.budgethunter.budgetList.data.BudgetRepository
+import com.meneses.budgethunter.budgetList.application.IDeleteBudgetUseCase
+import com.meneses.budgethunter.budgetList.application.IDuplicateBudgetUseCase
+import com.meneses.budgethunter.budgetList.data.IBudgetRepository
 import com.meneses.budgethunter.budgetList.domain.Budget
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -14,9 +14,9 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
 class BudgetListViewModel(
-    private val budgetRepository: BudgetRepository,
-    private val duplicateBudgetUseCase: DuplicateBudgetUseCase,
-    private val deleteBudgetUseCase: DeleteBudgetUseCase
+    private val budgetRepository: IBudgetRepository,
+    private val duplicateBudgetUseCase: IDuplicateBudgetUseCase,
+    private val deleteBudgetUseCase: IDeleteBudgetUseCase
 ) : ViewModel() {
     val uiState get() = _uiState.asStateFlow()
     private val _uiState = MutableStateFlow(BudgetListState())

--- a/composeApp/src/commonMain/kotlin/com/meneses/budgethunter/budgetList/application/DeleteBudgetUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/com/meneses/budgethunter/budgetList/application/DeleteBudgetUseCase.kt
@@ -9,8 +9,8 @@ class DeleteBudgetUseCase(
     private val budgetLocalDataSource: BudgetLocalDataSource,
     private val entriesLocalDataSource: BudgetEntryLocalDataSource,
     private val ioDispatcher: CoroutineDispatcher
-) {
-    suspend fun execute(budgetId: Long) = withContext(ioDispatcher) {
+) : IDeleteBudgetUseCase {
+    override suspend fun execute(budgetId: Long) = withContext(ioDispatcher) {
         budgetLocalDataSource.delete(budgetId)
         entriesLocalDataSource.deleteAllByBudgetId(budgetId)
     }

--- a/composeApp/src/commonMain/kotlin/com/meneses/budgethunter/budgetList/application/DuplicateBudgetUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/com/meneses/budgethunter/budgetList/application/DuplicateBudgetUseCase.kt
@@ -12,7 +12,7 @@ class DuplicateBudgetUseCase(
     private val budgetEntryRepository: BudgetEntryRepository,
     private val defaultDispatcher: CoroutineDispatcher
 ) : IDuplicateBudgetUseCase {
-    override suspend fun execute(budget: Budget) = withContext(defaultDispatcher) {
+    override suspend fun execute(budget: Budget): Budget = withContext(defaultDispatcher) {
         val updatedBudget = budget.copy(id = -1, name = budget.name + " (copy)")
         val copyBudgetId = budgetRepository.create(updatedBudget).id
         budgetEntryRepository
@@ -21,5 +21,6 @@ class DuplicateBudgetUseCase(
                 val updatedEntry = it.copy(id = -1, budgetId = copyBudgetId)
                 budgetEntryRepository.create(updatedEntry)
             }
+        budgetRepository.getById(copyBudgetId)
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/meneses/budgethunter/budgetList/application/DuplicateBudgetUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/com/meneses/budgethunter/budgetList/application/DuplicateBudgetUseCase.kt
@@ -11,8 +11,8 @@ class DuplicateBudgetUseCase(
     private val budgetRepository: BudgetRepository,
     private val budgetEntryRepository: BudgetEntryRepository,
     private val defaultDispatcher: CoroutineDispatcher
-) {
-    suspend fun execute(budget: Budget) = withContext(defaultDispatcher) {
+) : IDuplicateBudgetUseCase {
+    override suspend fun execute(budget: Budget) = withContext(defaultDispatcher) {
         val updatedBudget = budget.copy(id = -1, name = budget.name + " (copy)")
         val copyBudgetId = budgetRepository.create(updatedBudget).id
         budgetEntryRepository

--- a/composeApp/src/commonMain/kotlin/com/meneses/budgethunter/budgetList/application/DuplicateBudgetUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/com/meneses/budgethunter/budgetList/application/DuplicateBudgetUseCase.kt
@@ -21,6 +21,8 @@ class DuplicateBudgetUseCase(
                 val updatedEntry = it.copy(id = -1, budgetId = copyBudgetId)
                 budgetEntryRepository.create(updatedEntry)
             }
-        budgetRepository.getById(copyBudgetId)
+        requireNotNull(budgetRepository.getById(copyBudgetId)) {
+            "Budget with id $copyBudgetId not found after creation"
+        }
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/meneses/budgethunter/budgetList/application/IDeleteBudgetUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/com/meneses/budgethunter/budgetList/application/IDeleteBudgetUseCase.kt
@@ -1,0 +1,5 @@
+package com.meneses.budgethunter.budgetList.application
+
+interface IDeleteBudgetUseCase {
+    suspend fun execute(budgetId: Long)
+}

--- a/composeApp/src/commonMain/kotlin/com/meneses/budgethunter/budgetList/application/IDuplicateBudgetUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/com/meneses/budgethunter/budgetList/application/IDuplicateBudgetUseCase.kt
@@ -1,0 +1,7 @@
+package com.meneses.budgethunter.budgetList.application
+
+import com.meneses.budgethunter.budgetList.domain.Budget
+
+interface IDuplicateBudgetUseCase {
+    suspend fun execute(budget: Budget)
+}

--- a/composeApp/src/commonMain/kotlin/com/meneses/budgethunter/budgetList/application/IDuplicateBudgetUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/com/meneses/budgethunter/budgetList/application/IDuplicateBudgetUseCase.kt
@@ -3,5 +3,5 @@ package com.meneses.budgethunter.budgetList.application
 import com.meneses.budgethunter.budgetList.domain.Budget
 
 interface IDuplicateBudgetUseCase {
-    suspend fun execute(budget: Budget)
+    suspend fun execute(budget: Budget): Budget
 }

--- a/composeApp/src/commonMain/kotlin/com/meneses/budgethunter/budgetList/data/BudgetRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/meneses/budgethunter/budgetList/data/BudgetRepository.kt
@@ -10,24 +10,24 @@ import kotlinx.coroutines.withContext
 class BudgetRepository(
     private val localDataSource: BudgetLocalDataSource,
     private val ioDispatcher: CoroutineDispatcher
-) {
-    val budgets: Flow<List<Budget>>
+) : IBudgetRepository {
+    override val budgets: Flow<List<Budget>>
         get() = localDataSource.budgets
 
-    suspend fun getById(id: Int): Budget? =
+    override suspend fun getById(id: Int): Budget? =
         localDataSource.getById(id)
 
-    suspend fun getAllCached(): List<Budget> =
+    override suspend fun getAllCached(): List<Budget> =
         localDataSource.getAllCached()
 
-    suspend fun getAllFilteredBy(filter: BudgetFilter): List<Budget> =
+    override suspend fun getAllFilteredBy(filter: BudgetFilter): List<Budget> =
         localDataSource.getAllFilteredBy(filter)
 
-    suspend fun create(budget: Budget) = withContext(ioDispatcher) {
+    override suspend fun create(budget: Budget) = withContext(ioDispatcher) {
         localDataSource.create(budget)
     }
 
-    suspend fun update(budget: Budget) = withContext(ioDispatcher) {
+    override suspend fun update(budget: Budget) = withContext(ioDispatcher) {
         localDataSource.update(budget)
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/meneses/budgethunter/budgetList/data/IBudgetRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/meneses/budgethunter/budgetList/data/IBudgetRepository.kt
@@ -1,0 +1,14 @@
+package com.meneses.budgethunter.budgetList.data
+
+import com.meneses.budgethunter.budgetList.domain.Budget
+import com.meneses.budgethunter.budgetList.domain.BudgetFilter
+import kotlinx.coroutines.flow.Flow
+
+interface IBudgetRepository {
+    val budgets: Flow<List<Budget>>
+    suspend fun getById(id: Int): Budget?
+    suspend fun getAllCached(): List<Budget>
+    suspend fun getAllFilteredBy(filter: BudgetFilter): List<Budget>
+    suspend fun create(budget: Budget): Budget
+    suspend fun update(budget: Budget)
+}

--- a/composeApp/src/commonMain/kotlin/com/meneses/budgethunter/budgetMetrics/BudgetMetricsViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/meneses/budgethunter/budgetMetrics/BudgetMetricsViewModel.kt
@@ -4,14 +4,14 @@ import androidx.compose.ui.graphics.Color
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.meneses.budgethunter.budgetMetrics.application.BudgetMetricsState
-import com.meneses.budgethunter.budgetMetrics.application.GetTotalsPerCategoryUseCase
+import com.meneses.budgethunter.budgetMetrics.application.IGetTotalsPerCategoryUseCase
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
 class BudgetMetricsViewModel(
-    private val getTotalsPerCategoryUseCase: GetTotalsPerCategoryUseCase
+    private val getTotalsPerCategoryUseCase: IGetTotalsPerCategoryUseCase
 ) : ViewModel() {
     private val _uiState = MutableStateFlow(BudgetMetricsState())
     val uiState = _uiState.asStateFlow()

--- a/composeApp/src/commonMain/kotlin/com/meneses/budgethunter/budgetMetrics/application/GetTotalsPerCategoryUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/com/meneses/budgethunter/budgetMetrics/application/GetTotalsPerCategoryUseCase.kt
@@ -8,8 +8,8 @@ import kotlinx.coroutines.withContext
 class GetTotalsPerCategoryUseCase(
     private val budgetEntryLocalDataSource: BudgetEntryLocalDataSource,
     private val defaultDispatcher: CoroutineDispatcher
-) {
-    suspend fun execute(): Map<BudgetEntry.Category, Double> = withContext(defaultDispatcher) {
+) : IGetTotalsPerCategoryUseCase {
+    override suspend fun execute(): Map<BudgetEntry.Category, Double> = withContext(defaultDispatcher) {
         val categories = BudgetEntry
             .getCategories()
             .map { it }

--- a/composeApp/src/commonMain/kotlin/com/meneses/budgethunter/budgetMetrics/application/IGetTotalsPerCategoryUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/com/meneses/budgethunter/budgetMetrics/application/IGetTotalsPerCategoryUseCase.kt
@@ -1,0 +1,7 @@
+package com.meneses.budgethunter.budgetMetrics.application
+
+import com.meneses.budgethunter.budgetEntry.domain.BudgetEntry
+
+interface IGetTotalsPerCategoryUseCase {
+    suspend fun execute(): Map<BudgetEntry.Category, Double>
+}

--- a/composeApp/src/commonMain/kotlin/com/meneses/budgethunter/commons/application/IValidateFilePathUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/com/meneses/budgethunter/commons/application/IValidateFilePathUseCase.kt
@@ -1,0 +1,5 @@
+package com.meneses.budgethunter.commons.application
+
+interface IValidateFilePathUseCase {
+    suspend fun execute(filePath: String?): String?
+}

--- a/composeApp/src/commonMain/kotlin/com/meneses/budgethunter/commons/application/ValidateFilePathUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/com/meneses/budgethunter/commons/application/ValidateFilePathUseCase.kt
@@ -11,9 +11,9 @@ import kotlinx.coroutines.withContext
 class ValidateFilePathUseCase(
     private val fileManager: FileManager,
     private val ioDispatcher: CoroutineDispatcher
-) {
+) : IValidateFilePathUseCase {
 
-    suspend fun execute(filePath: String?): String? = withContext(ioDispatcher) {
+    override suspend fun execute(filePath: String?): String? = withContext(ioDispatcher) {
         if (filePath.isNullOrEmpty()) return@withContext null
 
         return@withContext try {

--- a/composeApp/src/commonMain/kotlin/com/meneses/budgethunter/commons/data/FileManager.kt
+++ b/composeApp/src/commonMain/kotlin/com/meneses/budgethunter/commons/data/FileManager.kt
@@ -4,33 +4,4 @@ package com.meneses.budgethunter.commons.data
  * Cross-platform file management interface for BudgetHunter.
  * Provides essential file operations for budget entry invoice handling.
  */
-expect class FileManager {
-
-    /**
-     * Saves file data to the platform-appropriate directory
-     * @param fileData The file data to save
-     * @return The absolute path to the saved file
-     */
-    fun saveFile(fileData: FileData): String
-
-    /**
-     * Deletes a file at the specified path
-     * @param filePath The absolute path to the file to delete
-     * @return true if file was successfully deleted, false otherwise
-     */
-    fun deleteFile(filePath: String): Boolean
-
-    /**
-     * Creates a platform-appropriate URI for the file
-     * @param filePath The absolute path to the file
-     * @return URI string for the file
-     */
-    fun createUri(filePath: String): String
-
-    /**
-     * Validates if a file exists at the specified path
-     * @param filePath The absolute path to check
-     * @return true if file exists, false otherwise
-     */
-    fun fileExists(filePath: String): Boolean
-}
+expect class FileManager() : IFileManager

--- a/composeApp/src/commonMain/kotlin/com/meneses/budgethunter/commons/data/IFileManager.kt
+++ b/composeApp/src/commonMain/kotlin/com/meneses/budgethunter/commons/data/IFileManager.kt
@@ -1,0 +1,36 @@
+package com.meneses.budgethunter.commons.data
+
+/**
+ * Cross-platform file management interface for BudgetHunter.
+ * Provides essential file operations for budget entry invoice handling.
+ */
+interface IFileManager {
+
+    /**
+     * Saves file data to the platform-appropriate directory
+     * @param fileData The file data to save
+     * @return The absolute path to the saved file
+     */
+    fun saveFile(fileData: FileData): String
+
+    /**
+     * Deletes a file at the specified path
+     * @param filePath The absolute path to the file to delete
+     * @return true if file was successfully deleted, false otherwise
+     */
+    fun deleteFile(filePath: String): Boolean
+
+    /**
+     * Creates a platform-appropriate URI for the file
+     * @param filePath The absolute path to the file
+     * @return URI string for the file
+     */
+    fun createUri(filePath: String): String
+
+    /**
+     * Validates if a file exists at the specified path
+     * @param filePath The absolute path to check
+     * @return true if file exists, false otherwise
+     */
+    fun fileExists(filePath: String): Boolean
+}

--- a/composeApp/src/commonMain/kotlin/com/meneses/budgethunter/commons/data/IPreferencesManager.kt
+++ b/composeApp/src/commonMain/kotlin/com/meneses/budgethunter/commons/data/IPreferencesManager.kt
@@ -1,0 +1,12 @@
+package com.meneses.budgethunter.commons.data
+
+interface IPreferencesManager {
+    suspend fun isSmsReadingEnabled(): Boolean
+    suspend fun setSmsReadingEnabled(value: Boolean)
+    suspend fun getDefaultBudgetId(): Int
+    suspend fun setDefaultBudgetId(value: Int)
+    suspend fun getSelectedBankIds(): Set<String>
+    suspend fun setSelectedBankIds(value: Set<String>)
+    suspend fun isAiProcessingEnabled(): Boolean
+    suspend fun setAiProcessingEnabled(value: Boolean)
+}

--- a/composeApp/src/commonMain/kotlin/com/meneses/budgethunter/commons/data/PreferencesManager.kt
+++ b/composeApp/src/commonMain/kotlin/com/meneses/budgethunter/commons/data/PreferencesManager.kt
@@ -9,37 +9,37 @@ import androidx.datastore.preferences.core.stringSetPreferencesKey
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.map
 
-class PreferencesManager(private val preferences: DataStore<Preferences>) {
+class PreferencesManager(private val preferences: DataStore<Preferences>) : IPreferencesManager {
 
-    suspend fun isSmsReadingEnabled() = preferences.data
+    override suspend fun isSmsReadingEnabled() = preferences.data
         .map { it[KEY_SMS_READING_ENABLED] }
         .firstOrNull() == true
 
-    suspend fun setSmsReadingEnabled(value: Boolean) {
+    override suspend fun setSmsReadingEnabled(value: Boolean) {
         preferences.edit { it[KEY_SMS_READING_ENABLED] = value }
     }
 
-    suspend fun getDefaultBudgetId() = preferences.data
+    override suspend fun getDefaultBudgetId() = preferences.data
         .map { it[KEY_DEFAULT_BUDGET_ID] }
         .firstOrNull() ?: -1
 
-    suspend fun setDefaultBudgetId(value: Int) {
+    override suspend fun setDefaultBudgetId(value: Int) {
         preferences.edit { it[KEY_DEFAULT_BUDGET_ID] = value }
     }
 
-    suspend fun getSelectedBankIds() = preferences.data
+    override suspend fun getSelectedBankIds() = preferences.data
         .map { it[KEY_SELECTED_BANK_IDS] }
         .firstOrNull() ?: emptySet()
 
-    suspend fun setSelectedBankIds(value: Set<String>) {
+    override suspend fun setSelectedBankIds(value: Set<String>) {
         preferences.edit { it[KEY_SELECTED_BANK_IDS] = value }
     }
 
-    suspend fun isAiProcessingEnabled() = preferences.data
+    override suspend fun isAiProcessingEnabled() = preferences.data
         .map { it[KEY_AI_PROCESSING_ENABLED] }
         .firstOrNull() != false
 
-    suspend fun setAiProcessingEnabled(value: Boolean) {
+    override suspend fun setAiProcessingEnabled(value: Boolean) {
         preferences.edit { it[KEY_AI_PROCESSING_ENABLED] = value }
     }
 

--- a/composeApp/src/commonMain/kotlin/com/meneses/budgethunter/commons/platform/AppUpdateManager.kt
+++ b/composeApp/src/commonMain/kotlin/com/meneses/budgethunter/commons/platform/AppUpdateManager.kt
@@ -1,3 +1,5 @@
+@file:Suppress("MatchingDeclarationName")
+
 package com.meneses.budgethunter.commons.platform
 
 sealed class AppUpdateResult {

--- a/composeApp/src/commonMain/kotlin/com/meneses/budgethunter/commons/platform/AppUpdateManager.kt
+++ b/composeApp/src/commonMain/kotlin/com/meneses/budgethunter/commons/platform/AppUpdateManager.kt
@@ -7,8 +7,5 @@ sealed class AppUpdateResult {
     data object UpdateFailed : AppUpdateResult()
 }
 
-/**
- * Cross-platform app update manager interface.
- * Platform-specific implementations are provided in androidMain and iosMain.
- */
-expect class AppUpdateManager() : IAppUpdateManager
+// Platform-specific implementations are provided in androidMain and iosMain
+// Use IAppUpdateManager interface for dependency injection

--- a/composeApp/src/commonMain/kotlin/com/meneses/budgethunter/commons/platform/AppUpdateManager.kt
+++ b/composeApp/src/commonMain/kotlin/com/meneses/budgethunter/commons/platform/AppUpdateManager.kt
@@ -1,5 +1,3 @@
-@file:Suppress("MatchingDeclarationName")
-
 package com.meneses.budgethunter.commons.platform
 
 sealed class AppUpdateResult {
@@ -9,5 +7,8 @@ sealed class AppUpdateResult {
     data object UpdateFailed : AppUpdateResult()
 }
 
-// Platform-specific implementations are provided in androidMain and iosMain
-// They implement IAppUpdateManager interface
+/**
+ * Cross-platform app update manager interface.
+ * Platform-specific implementations are provided in androidMain and iosMain.
+ */
+expect class AppUpdateManager() : IAppUpdateManager

--- a/composeApp/src/commonMain/kotlin/com/meneses/budgethunter/commons/platform/AppUpdateManager.kt
+++ b/composeApp/src/commonMain/kotlin/com/meneses/budgethunter/commons/platform/AppUpdateManager.kt
@@ -7,6 +7,4 @@ sealed class AppUpdateResult {
     data object UpdateFailed : AppUpdateResult()
 }
 
-expect class AppUpdateManager {
-    fun checkForUpdates(onResult: (AppUpdateResult) -> Unit)
-}
+expect class AppUpdateManager() : IAppUpdateManager

--- a/composeApp/src/commonMain/kotlin/com/meneses/budgethunter/commons/platform/AppUpdateManager.kt
+++ b/composeApp/src/commonMain/kotlin/com/meneses/budgethunter/commons/platform/AppUpdateManager.kt
@@ -1,11 +1,4 @@
 package com.meneses.budgethunter.commons.platform
 
-sealed class AppUpdateResult {
-    data object NoUpdateAvailable : AppUpdateResult()
-    data object UpdateInProgress : AppUpdateResult()
-    data class UpdateAvailable(val startUpdate: () -> Unit) : AppUpdateResult()
-    data object UpdateFailed : AppUpdateResult()
-}
-
 // Platform-specific implementations are provided in androidMain and iosMain
 // Use IAppUpdateManager interface for dependency injection

--- a/composeApp/src/commonMain/kotlin/com/meneses/budgethunter/commons/platform/AppUpdateManager.kt
+++ b/composeApp/src/commonMain/kotlin/com/meneses/budgethunter/commons/platform/AppUpdateManager.kt
@@ -7,4 +7,5 @@ sealed class AppUpdateResult {
     data object UpdateFailed : AppUpdateResult()
 }
 
-expect class AppUpdateManager() : IAppUpdateManager
+// Platform-specific implementations are provided in androidMain and iosMain
+// They implement IAppUpdateManager interface

--- a/composeApp/src/commonMain/kotlin/com/meneses/budgethunter/commons/platform/AppUpdateResult.kt
+++ b/composeApp/src/commonMain/kotlin/com/meneses/budgethunter/commons/platform/AppUpdateResult.kt
@@ -1,0 +1,8 @@
+package com.meneses.budgethunter.commons.platform
+
+sealed class AppUpdateResult {
+    data object NoUpdateAvailable : AppUpdateResult()
+    data object UpdateInProgress : AppUpdateResult()
+    data class UpdateAvailable(val startUpdate: () -> Unit) : AppUpdateResult()
+    data object UpdateFailed : AppUpdateResult()
+}

--- a/composeApp/src/commonMain/kotlin/com/meneses/budgethunter/commons/platform/IAppUpdateManager.kt
+++ b/composeApp/src/commonMain/kotlin/com/meneses/budgethunter/commons/platform/IAppUpdateManager.kt
@@ -1,0 +1,5 @@
+package com.meneses.budgethunter.commons.platform
+
+interface IAppUpdateManager {
+    fun checkForUpdates(onResult: (AppUpdateResult) -> Unit)
+}

--- a/composeApp/src/commonMain/kotlin/com/meneses/budgethunter/commons/platform/IPermissionsManager.kt
+++ b/composeApp/src/commonMain/kotlin/com/meneses/budgethunter/commons/platform/IPermissionsManager.kt
@@ -1,0 +1,8 @@
+package com.meneses.budgethunter.commons.platform
+
+interface IPermissionsManager {
+    fun hasSmsPermission(): Boolean
+    fun requestSmsPermissions(callback: (granted: Boolean) -> Unit)
+    fun openAppSettings()
+    fun shouldShowSMSPermissionRationale(): Boolean
+}

--- a/composeApp/src/commonMain/kotlin/com/meneses/budgethunter/commons/platform/PermissionsManager.kt
+++ b/composeApp/src/commonMain/kotlin/com/meneses/budgethunter/commons/platform/PermissionsManager.kt
@@ -1,7 +1,4 @@
 package com.meneses.budgethunter.commons.platform
 
-/**
- * Cross-platform permissions manager interface.
- * Platform-specific implementations are provided in androidMain and iosMain.
- */
-expect class PermissionsManager() : IPermissionsManager
+// Platform-specific implementations are provided in androidMain and iosMain
+// Use IPermissionsManager interface for dependency injection

--- a/composeApp/src/commonMain/kotlin/com/meneses/budgethunter/commons/platform/PermissionsManager.kt
+++ b/composeApp/src/commonMain/kotlin/com/meneses/budgethunter/commons/platform/PermissionsManager.kt
@@ -1,8 +1,3 @@
 package com.meneses.budgethunter.commons.platform
 
-expect class PermissionsManager {
-    fun hasSmsPermission(): Boolean
-    fun requestSmsPermissions(callback: (granted: Boolean) -> Unit)
-    fun openAppSettings()
-    fun shouldShowSMSPermissionRationale(): Boolean
-}
+expect class PermissionsManager() : IPermissionsManager

--- a/composeApp/src/commonMain/kotlin/com/meneses/budgethunter/commons/platform/PermissionsManager.kt
+++ b/composeApp/src/commonMain/kotlin/com/meneses/budgethunter/commons/platform/PermissionsManager.kt
@@ -1,3 +1,4 @@
 package com.meneses.budgethunter.commons.platform
 
-expect class PermissionsManager() : IPermissionsManager
+// Platform-specific implementations are provided in androidMain and iosMain
+// They implement IPermissionsManager interface

--- a/composeApp/src/commonMain/kotlin/com/meneses/budgethunter/commons/platform/PermissionsManager.kt
+++ b/composeApp/src/commonMain/kotlin/com/meneses/budgethunter/commons/platform/PermissionsManager.kt
@@ -1,4 +1,7 @@
 package com.meneses.budgethunter.commons.platform
 
-// Platform-specific implementations are provided in androidMain and iosMain
-// They implement IPermissionsManager interface
+/**
+ * Cross-platform permissions manager interface.
+ * Platform-specific implementations are provided in androidMain and iosMain.
+ */
+expect class PermissionsManager() : IPermissionsManager

--- a/composeApp/src/commonMain/kotlin/com/meneses/budgethunter/di/BudgetDetailModule.kt
+++ b/composeApp/src/commonMain/kotlin/com/meneses/budgethunter/di/BudgetDetailModule.kt
@@ -7,7 +7,6 @@ import com.meneses.budgethunter.budgetEntry.data.datasource.BudgetEntryLocalData
 import com.meneses.budgethunter.budgetList.application.DeleteBudgetUseCase
 import com.meneses.budgethunter.budgetList.data.datasource.BudgetLocalDataSource
 import kotlinx.coroutines.CoroutineDispatcher
-import org.koin.core.module.dsl.bind
 import org.koin.core.qualifier.named
 import org.koin.dsl.module
 
@@ -20,7 +19,9 @@ val budgetDetailModule = module {
             get<CoroutineDispatcher>(named("IO")),
             get<DeleteBudgetUseCase>()
         )
-    } bind IBudgetDetailRepository::class
+    }
+
+    single<IBudgetDetailRepository> { get<BudgetDetailRepository>() }
 
     factory<BudgetDetailViewModel> {
         BudgetDetailViewModel(

--- a/composeApp/src/commonMain/kotlin/com/meneses/budgethunter/di/BudgetDetailModule.kt
+++ b/composeApp/src/commonMain/kotlin/com/meneses/budgethunter/di/BudgetDetailModule.kt
@@ -7,6 +7,7 @@ import com.meneses.budgethunter.budgetEntry.data.datasource.BudgetEntryLocalData
 import com.meneses.budgethunter.budgetList.application.DeleteBudgetUseCase
 import com.meneses.budgethunter.budgetList.data.datasource.BudgetLocalDataSource
 import kotlinx.coroutines.CoroutineDispatcher
+import org.koin.core.module.dsl.bind
 import org.koin.core.qualifier.named
 import org.koin.dsl.module
 

--- a/composeApp/src/commonMain/kotlin/com/meneses/budgethunter/di/BudgetDetailModule.kt
+++ b/composeApp/src/commonMain/kotlin/com/meneses/budgethunter/di/BudgetDetailModule.kt
@@ -2,6 +2,7 @@ package com.meneses.budgethunter.di
 
 import com.meneses.budgethunter.budgetDetail.BudgetDetailViewModel
 import com.meneses.budgethunter.budgetDetail.data.BudgetDetailRepository
+import com.meneses.budgethunter.budgetDetail.data.IBudgetDetailRepository
 import com.meneses.budgethunter.budgetEntry.data.datasource.BudgetEntryLocalDataSource
 import com.meneses.budgethunter.budgetList.application.DeleteBudgetUseCase
 import com.meneses.budgethunter.budgetList.data.datasource.BudgetLocalDataSource
@@ -18,7 +19,7 @@ val budgetDetailModule = module {
             get<CoroutineDispatcher>(named("IO")),
             get<DeleteBudgetUseCase>()
         )
-    }
+    } bind IBudgetDetailRepository::class
 
     factory<BudgetDetailViewModel> {
         BudgetDetailViewModel(

--- a/composeApp/src/commonMain/kotlin/com/meneses/budgethunter/di/BudgetEntryModule.kt
+++ b/composeApp/src/commonMain/kotlin/com/meneses/budgethunter/di/BudgetEntryModule.kt
@@ -9,6 +9,7 @@ import com.meneses.budgethunter.budgetEntry.data.datasource.BudgetEntryLocalData
 import com.meneses.budgethunter.budgetEntry.domain.AIImageProcessor
 import com.meneses.budgethunter.db.BudgetEntryQueries
 import kotlinx.coroutines.CoroutineDispatcher
+import org.koin.core.module.dsl.bind
 import org.koin.core.qualifier.named
 import org.koin.dsl.module
 

--- a/composeApp/src/commonMain/kotlin/com/meneses/budgethunter/di/BudgetEntryModule.kt
+++ b/composeApp/src/commonMain/kotlin/com/meneses/budgethunter/di/BudgetEntryModule.kt
@@ -2,7 +2,9 @@ package com.meneses.budgethunter.di
 
 import com.meneses.budgethunter.budgetEntry.BudgetEntryViewModel
 import com.meneses.budgethunter.budgetEntry.application.CreateBudgetEntryFromImageUseCase
+import com.meneses.budgethunter.budgetEntry.application.ICreateBudgetEntryFromImageUseCase
 import com.meneses.budgethunter.budgetEntry.data.BudgetEntryRepository
+import com.meneses.budgethunter.budgetEntry.data.IBudgetEntryRepository
 import com.meneses.budgethunter.budgetEntry.data.datasource.BudgetEntryLocalDataSource
 import com.meneses.budgethunter.budgetEntry.domain.AIImageProcessor
 import com.meneses.budgethunter.db.BudgetEntryQueries
@@ -18,7 +20,7 @@ val budgetEntryModule = module {
 
     single<BudgetEntryRepository> {
         BudgetEntryRepository(get<BudgetEntryLocalDataSource>(), get<CoroutineDispatcher>(named("IO")))
-    }
+    } bind IBudgetEntryRepository::class
 
     // AI image processing use case
     single<CreateBudgetEntryFromImageUseCase> {
@@ -26,7 +28,7 @@ val budgetEntryModule = module {
             aiImageProcessor = get<AIImageProcessor>(),
             ioDispatcher = get<CoroutineDispatcher>(named("IO"))
         )
-    }
+    } bind ICreateBudgetEntryFromImageUseCase::class
 
     // BudgetEntryViewModel with all required dependencies
     factory {

--- a/composeApp/src/commonMain/kotlin/com/meneses/budgethunter/di/BudgetEntryModule.kt
+++ b/composeApp/src/commonMain/kotlin/com/meneses/budgethunter/di/BudgetEntryModule.kt
@@ -9,7 +9,6 @@ import com.meneses.budgethunter.budgetEntry.data.datasource.BudgetEntryLocalData
 import com.meneses.budgethunter.budgetEntry.domain.AIImageProcessor
 import com.meneses.budgethunter.db.BudgetEntryQueries
 import kotlinx.coroutines.CoroutineDispatcher
-import org.koin.core.module.dsl.bind
 import org.koin.core.qualifier.named
 import org.koin.dsl.module
 
@@ -21,7 +20,9 @@ val budgetEntryModule = module {
 
     single<BudgetEntryRepository> {
         BudgetEntryRepository(get<BudgetEntryLocalDataSource>(), get<CoroutineDispatcher>(named("IO")))
-    } bind IBudgetEntryRepository::class
+    }
+
+    single<IBudgetEntryRepository> { get<BudgetEntryRepository>() }
 
     // AI image processing use case
     single<CreateBudgetEntryFromImageUseCase> {
@@ -29,7 +30,9 @@ val budgetEntryModule = module {
             aiImageProcessor = get<AIImageProcessor>(),
             ioDispatcher = get<CoroutineDispatcher>(named("IO"))
         )
-    } bind ICreateBudgetEntryFromImageUseCase::class
+    }
+
+    single<ICreateBudgetEntryFromImageUseCase> { get<CreateBudgetEntryFromImageUseCase>() }
 
     // BudgetEntryViewModel with all required dependencies
     factory {

--- a/composeApp/src/commonMain/kotlin/com/meneses/budgethunter/di/BudgetListModule.kt
+++ b/composeApp/src/commonMain/kotlin/com/meneses/budgethunter/di/BudgetListModule.kt
@@ -12,6 +12,7 @@ import com.meneses.budgethunter.budgetList.data.IBudgetRepository
 import com.meneses.budgethunter.budgetList.data.datasource.BudgetLocalDataSource
 import com.meneses.budgethunter.db.BudgetQueries
 import kotlinx.coroutines.CoroutineDispatcher
+import org.koin.core.module.dsl.bind
 import org.koin.core.qualifier.named
 import org.koin.dsl.module
 

--- a/composeApp/src/commonMain/kotlin/com/meneses/budgethunter/di/BudgetListModule.kt
+++ b/composeApp/src/commonMain/kotlin/com/meneses/budgethunter/di/BudgetListModule.kt
@@ -12,7 +12,6 @@ import com.meneses.budgethunter.budgetList.data.IBudgetRepository
 import com.meneses.budgethunter.budgetList.data.datasource.BudgetLocalDataSource
 import com.meneses.budgethunter.db.BudgetQueries
 import kotlinx.coroutines.CoroutineDispatcher
-import org.koin.core.module.dsl.bind
 import org.koin.core.qualifier.named
 import org.koin.dsl.module
 
@@ -24,7 +23,9 @@ val budgetListModule = module {
 
     single<BudgetRepository> {
         BudgetRepository(get<BudgetLocalDataSource>(), get<CoroutineDispatcher>(named("IO")))
-    } bind IBudgetRepository::class
+    }
+
+    single<IBudgetRepository> { get<BudgetRepository>() }
 
     single<DuplicateBudgetUseCase> {
         DuplicateBudgetUseCase(
@@ -32,7 +33,9 @@ val budgetListModule = module {
             get<BudgetEntryRepository>(),
             get<CoroutineDispatcher>(named("Default"))
         )
-    } bind IDuplicateBudgetUseCase::class
+    }
+
+    single<IDuplicateBudgetUseCase> { get<DuplicateBudgetUseCase>() }
 
     single<DeleteBudgetUseCase> {
         DeleteBudgetUseCase(
@@ -40,7 +43,9 @@ val budgetListModule = module {
             get<BudgetEntryLocalDataSource>(),
             get<CoroutineDispatcher>(named("IO"))
         )
-    } bind IDeleteBudgetUseCase::class
+    }
+
+    single<IDeleteBudgetUseCase> { get<DeleteBudgetUseCase>() }
 
     factory<BudgetListViewModel> {
         BudgetListViewModel(

--- a/composeApp/src/commonMain/kotlin/com/meneses/budgethunter/di/BudgetListModule.kt
+++ b/composeApp/src/commonMain/kotlin/com/meneses/budgethunter/di/BudgetListModule.kt
@@ -4,8 +4,11 @@ import com.meneses.budgethunter.budgetEntry.data.BudgetEntryRepository
 import com.meneses.budgethunter.budgetEntry.data.datasource.BudgetEntryLocalDataSource
 import com.meneses.budgethunter.budgetList.BudgetListViewModel
 import com.meneses.budgethunter.budgetList.application.DeleteBudgetUseCase
+import com.meneses.budgethunter.budgetList.application.IDeleteBudgetUseCase
 import com.meneses.budgethunter.budgetList.application.DuplicateBudgetUseCase
+import com.meneses.budgethunter.budgetList.application.IDuplicateBudgetUseCase
 import com.meneses.budgethunter.budgetList.data.BudgetRepository
+import com.meneses.budgethunter.budgetList.data.IBudgetRepository
 import com.meneses.budgethunter.budgetList.data.datasource.BudgetLocalDataSource
 import com.meneses.budgethunter.db.BudgetQueries
 import kotlinx.coroutines.CoroutineDispatcher
@@ -20,7 +23,7 @@ val budgetListModule = module {
 
     single<BudgetRepository> {
         BudgetRepository(get<BudgetLocalDataSource>(), get<CoroutineDispatcher>(named("IO")))
-    }
+    } bind IBudgetRepository::class
 
     single<DuplicateBudgetUseCase> {
         DuplicateBudgetUseCase(
@@ -28,7 +31,7 @@ val budgetListModule = module {
             get<BudgetEntryRepository>(),
             get<CoroutineDispatcher>(named("Default"))
         )
-    }
+    } bind IDuplicateBudgetUseCase::class
 
     single<DeleteBudgetUseCase> {
         DeleteBudgetUseCase(
@@ -36,7 +39,7 @@ val budgetListModule = module {
             get<BudgetEntryLocalDataSource>(),
             get<CoroutineDispatcher>(named("IO"))
         )
-    }
+    } bind IDeleteBudgetUseCase::class
 
     factory<BudgetListViewModel> {
         BudgetListViewModel(

--- a/composeApp/src/commonMain/kotlin/com/meneses/budgethunter/di/BudgetMetricsModule.kt
+++ b/composeApp/src/commonMain/kotlin/com/meneses/budgethunter/di/BudgetMetricsModule.kt
@@ -3,17 +3,18 @@ package com.meneses.budgethunter.di
 import com.meneses.budgethunter.budgetEntry.data.datasource.BudgetEntryLocalDataSource
 import com.meneses.budgethunter.budgetMetrics.BudgetMetricsViewModel
 import com.meneses.budgethunter.budgetMetrics.application.GetTotalsPerCategoryUseCase
+import com.meneses.budgethunter.budgetMetrics.application.IGetTotalsPerCategoryUseCase
 import kotlinx.coroutines.CoroutineDispatcher
 import org.koin.core.qualifier.named
 import org.koin.dsl.module
 
 val budgetMetricsModule = module {
-    single {
+    single<GetTotalsPerCategoryUseCase> {
         GetTotalsPerCategoryUseCase(
             budgetEntryLocalDataSource = get<BudgetEntryLocalDataSource>(),
             defaultDispatcher = get<CoroutineDispatcher>(named("Default"))
         )
-    }
+    } bind IGetTotalsPerCategoryUseCase::class
 
     factory {
         BudgetMetricsViewModel(

--- a/composeApp/src/commonMain/kotlin/com/meneses/budgethunter/di/BudgetMetricsModule.kt
+++ b/composeApp/src/commonMain/kotlin/com/meneses/budgethunter/di/BudgetMetricsModule.kt
@@ -5,7 +5,6 @@ import com.meneses.budgethunter.budgetMetrics.BudgetMetricsViewModel
 import com.meneses.budgethunter.budgetMetrics.application.GetTotalsPerCategoryUseCase
 import com.meneses.budgethunter.budgetMetrics.application.IGetTotalsPerCategoryUseCase
 import kotlinx.coroutines.CoroutineDispatcher
-import org.koin.core.module.dsl.bind
 import org.koin.core.qualifier.named
 import org.koin.dsl.module
 
@@ -15,7 +14,9 @@ val budgetMetricsModule = module {
             budgetEntryLocalDataSource = get<BudgetEntryLocalDataSource>(),
             defaultDispatcher = get<CoroutineDispatcher>(named("Default"))
         )
-    } bind IGetTotalsPerCategoryUseCase::class
+    }
+
+    single<IGetTotalsPerCategoryUseCase> { get<GetTotalsPerCategoryUseCase>() }
 
     factory {
         BudgetMetricsViewModel(

--- a/composeApp/src/commonMain/kotlin/com/meneses/budgethunter/di/BudgetMetricsModule.kt
+++ b/composeApp/src/commonMain/kotlin/com/meneses/budgethunter/di/BudgetMetricsModule.kt
@@ -5,6 +5,7 @@ import com.meneses.budgethunter.budgetMetrics.BudgetMetricsViewModel
 import com.meneses.budgethunter.budgetMetrics.application.GetTotalsPerCategoryUseCase
 import com.meneses.budgethunter.budgetMetrics.application.IGetTotalsPerCategoryUseCase
 import kotlinx.coroutines.CoroutineDispatcher
+import org.koin.core.module.dsl.bind
 import org.koin.core.qualifier.named
 import org.koin.dsl.module
 

--- a/composeApp/src/commonMain/kotlin/com/meneses/budgethunter/di/CommonModule.kt
+++ b/composeApp/src/commonMain/kotlin/com/meneses/budgethunter/di/CommonModule.kt
@@ -2,7 +2,9 @@ package com.meneses.budgethunter.di
 
 import com.meneses.budgethunter.budgetList.data.adapter.categoryAdapter
 import com.meneses.budgethunter.budgetList.data.adapter.typeAdapter
+import com.meneses.budgethunter.commons.application.IValidateFilePathUseCase
 import com.meneses.budgethunter.commons.application.ValidateFilePathUseCase
+import com.meneses.budgethunter.commons.data.IPreferencesManager
 import com.meneses.budgethunter.commons.data.PreferencesManager
 import com.meneses.budgethunter.db.BudgetEntryQueries
 import com.meneses.budgethunter.db.BudgetQueries
@@ -41,12 +43,12 @@ val commonModule = module {
         }
     }
 
-    single<PreferencesManager> { PreferencesManager(get()) }
+    single<PreferencesManager> { PreferencesManager(get()) } bind IPreferencesManager::class
 
     single<ValidateFilePathUseCase> {
         ValidateFilePathUseCase(
             fileManager = get(),
             ioDispatcher = get(named("IO"))
         )
-    }
+    } bind IValidateFilePathUseCase::class
 }

--- a/composeApp/src/commonMain/kotlin/com/meneses/budgethunter/di/CommonModule.kt
+++ b/composeApp/src/commonMain/kotlin/com/meneses/budgethunter/di/CommonModule.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
 import kotlinx.serialization.json.Json
+import org.koin.core.module.dsl.bind
 import org.koin.core.qualifier.named
 import org.koin.dsl.module
 

--- a/composeApp/src/commonMain/kotlin/com/meneses/budgethunter/di/CommonModule.kt
+++ b/composeApp/src/commonMain/kotlin/com/meneses/budgethunter/di/CommonModule.kt
@@ -15,7 +15,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
 import kotlinx.serialization.json.Json
-import org.koin.core.module.dsl.bind
 import org.koin.core.qualifier.named
 import org.koin.dsl.module
 
@@ -44,12 +43,16 @@ val commonModule = module {
         }
     }
 
-    single<PreferencesManager> { PreferencesManager(get()) } bind IPreferencesManager::class
+    single<PreferencesManager> { PreferencesManager(get()) }
+
+    single<IPreferencesManager> { get<PreferencesManager>() }
 
     single<ValidateFilePathUseCase> {
         ValidateFilePathUseCase(
             fileManager = get(),
             ioDispatcher = get(named("IO"))
         )
-    } bind IValidateFilePathUseCase::class
+    }
+
+    single<IValidateFilePathUseCase> { get<ValidateFilePathUseCase>() }
 }

--- a/composeApp/src/commonMain/kotlin/com/meneses/budgethunter/di/SettingsModule.kt
+++ b/composeApp/src/commonMain/kotlin/com/meneses/budgethunter/di/SettingsModule.kt
@@ -1,8 +1,8 @@
 package com.meneses.budgethunter.di
 
-import com.meneses.budgethunter.budgetList.data.BudgetRepository
-import com.meneses.budgethunter.commons.data.PreferencesManager
-import com.meneses.budgethunter.commons.platform.PermissionsManager
+import com.meneses.budgethunter.budgetList.data.IBudgetRepository
+import com.meneses.budgethunter.commons.data.IPreferencesManager
+import com.meneses.budgethunter.commons.platform.IPermissionsManager
 import com.meneses.budgethunter.settings.SettingsViewModel
 import org.koin.dsl.module
 
@@ -10,9 +10,9 @@ val settingsModule = module {
 
     factory<SettingsViewModel> {
         SettingsViewModel(
-            preferencesManager = get<PreferencesManager>(),
-            budgetRepository = get<BudgetRepository>(),
-            permissionsManager = get<PermissionsManager>()
+            preferencesManager = get<IPreferencesManager>(),
+            budgetRepository = get<IBudgetRepository>(),
+            permissionsManager = get<IPermissionsManager>()
         )
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/meneses/budgethunter/di/SplashModule.kt
+++ b/composeApp/src/commonMain/kotlin/com/meneses/budgethunter/di/SplashModule.kt
@@ -1,11 +1,11 @@
 package com.meneses.budgethunter.di
 
-import com.meneses.budgethunter.commons.platform.AppUpdateManager
+import com.meneses.budgethunter.commons.platform.IAppUpdateManager
 import com.meneses.budgethunter.splash.SplashScreenViewModel
 import org.koin.dsl.module
 
 val splashModule = module {
     factory<SplashScreenViewModel> {
-        SplashScreenViewModel(get<AppUpdateManager>())
+        SplashScreenViewModel(get<IAppUpdateManager>())
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/meneses/budgethunter/settings/SettingsViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/meneses/budgethunter/settings/SettingsViewModel.kt
@@ -2,10 +2,10 @@ package com.meneses.budgethunter.settings
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.meneses.budgethunter.budgetList.data.BudgetRepository
+import com.meneses.budgethunter.budgetList.data.IBudgetRepository
 import com.meneses.budgethunter.budgetList.domain.Budget
-import com.meneses.budgethunter.commons.data.PreferencesManager
-import com.meneses.budgethunter.commons.platform.PermissionsManager
+import com.meneses.budgethunter.commons.data.IPreferencesManager
+import com.meneses.budgethunter.commons.platform.IPermissionsManager
 import com.meneses.budgethunter.settings.application.SettingsEvent
 import com.meneses.budgethunter.settings.application.SettingsState
 import com.meneses.budgethunter.sms.domain.SupportedBanks
@@ -15,9 +15,9 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
 class SettingsViewModel(
-    private val preferencesManager: PreferencesManager,
-    private val budgetRepository: BudgetRepository,
-    private val permissionsManager: PermissionsManager
+    private val preferencesManager: IPreferencesManager,
+    private val budgetRepository: IBudgetRepository,
+    private val permissionsManager: IPermissionsManager
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(SettingsState())

--- a/composeApp/src/commonMain/kotlin/com/meneses/budgethunter/splash/SplashScreenViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/meneses/budgethunter/splash/SplashScreenViewModel.kt
@@ -1,8 +1,8 @@
 package com.meneses.budgethunter.splash
 
 import androidx.lifecycle.ViewModel
-import com.meneses.budgethunter.commons.platform.AppUpdateManager
 import com.meneses.budgethunter.commons.platform.AppUpdateResult
+import com.meneses.budgethunter.commons.platform.IAppUpdateManager
 import com.meneses.budgethunter.splash.application.SplashEvent
 import com.meneses.budgethunter.splash.application.SplashState
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -10,7 +10,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 
 class SplashScreenViewModel(
-    private val appUpdateManager: AppUpdateManager
+    private val appUpdateManager: IAppUpdateManager
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(SplashState())

--- a/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/budgetDetail/BudgetDetailViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/budgetDetail/BudgetDetailViewModelTest.kt
@@ -1,0 +1,369 @@
+package com.meneses.budgethunter.budgetDetail
+
+import com.meneses.budgethunter.budgetDetail.application.BudgetDetailEvent
+import com.meneses.budgethunter.budgetDetail.application.BudgetDetailState
+import com.meneses.budgethunter.budgetDetail.data.BudgetDetailRepository
+import com.meneses.budgethunter.budgetDetail.domain.BudgetDetail
+import com.meneses.budgethunter.budgetEntry.domain.BudgetEntry
+import com.meneses.budgethunter.budgetEntry.domain.BudgetEntryFilter
+import com.meneses.budgethunter.budgetList.domain.Budget
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class BudgetDetailViewModelTest {
+
+    private class FakeBudgetDetailRepository : BudgetDetailRepository {
+        var cachedDetail = BudgetDetail()
+        val deletedBudgetIds = mutableListOf<Int>()
+        val deletedEntryIds = mutableListOf<List<Int>>()
+        val updatedAmounts = mutableListOf<Double>()
+
+        override suspend fun getBudgetDetailById(budgetId: Int): Flow<BudgetDetail> {
+            return flowOf(cachedDetail)
+        }
+
+        override suspend fun getCachedDetail(): BudgetDetail = cachedDetail
+
+        override suspend fun getAllFilteredBy(filter: BudgetEntryFilter): BudgetDetail {
+            return cachedDetail.copy(
+                entries = cachedDetail.entries.filter {
+                    when (filter) {
+                        is BudgetEntryFilter.ByCategory -> it.category == filter.category
+                        is BudgetEntryFilter.ByType -> it.type == filter.type
+                        else -> true
+                    }
+                }
+            )
+        }
+
+        override suspend fun deleteBudget(budgetId: Int) {
+            deletedBudgetIds.add(budgetId)
+        }
+
+        override suspend fun deleteEntriesByIds(ids: List<Int>) {
+            deletedEntryIds.add(ids)
+        }
+
+        override suspend fun updateBudgetAmount(amount: Double) {
+            updatedAmounts.add(amount)
+        }
+    }
+
+    @Test
+    fun `initial state is loading`() = runTest {
+        val repository = FakeBudgetDetailRepository()
+        val viewModel = BudgetDetailViewModel(repository)
+
+        val state = viewModel.uiState.value
+        assertTrue(state.isLoading)
+    }
+
+    @Test
+    fun `setBudget updates budget in state`() = runTest {
+        val repository = FakeBudgetDetailRepository()
+        val viewModel = BudgetDetailViewModel(repository)
+
+        val budget = Budget(id = 1, name = "Test Budget", amount = 100.0)
+        viewModel.sendEvent(BudgetDetailEvent.SetBudget(budget))
+
+        val state = viewModel.uiState.value
+        assertEquals(budget, state.budgetDetail.budget)
+    }
+
+    @Test
+    fun `getBudgetDetail loads detail from repository`() = runTest {
+        val entries = listOf(
+            BudgetEntry(id = 1, budgetId = 1, amount = "50"),
+            BudgetEntry(id = 2, budgetId = 1, amount = "30")
+        )
+        val budget = Budget(id = 1, name = "Test", amount = 100.0)
+        val detail = BudgetDetail(budget = budget, entries = entries)
+
+        val repository = FakeBudgetDetailRepository()
+        repository.cachedDetail = detail
+
+        val viewModel = BudgetDetailViewModel(repository)
+        viewModel.sendEvent(BudgetDetailEvent.SetBudget(budget))
+        viewModel.sendEvent(BudgetDetailEvent.GetBudgetDetail)
+
+        kotlinx.coroutines.delay(100)
+
+        val state = viewModel.uiState.value
+        assertFalse(state.isLoading)
+        assertEquals(2, state.budgetDetail.entries.size)
+    }
+
+    @Test
+    fun `updateBudgetAmount calls repository`() = runTest {
+        val repository = FakeBudgetDetailRepository()
+        val viewModel = BudgetDetailViewModel(repository)
+
+        viewModel.sendEvent(BudgetDetailEvent.UpdateBudgetAmount(500.0))
+
+        kotlinx.coroutines.delay(100)
+
+        assertEquals(listOf(500.0), repository.updatedAmounts)
+    }
+
+    @Test
+    fun `filterEntries applies filter to entries`() = runTest {
+        val entries = listOf(
+            BudgetEntry(id = 1, budgetId = 1, amount = "50", type = BudgetEntry.Type.INCOME),
+            BudgetEntry(id = 2, budgetId = 1, amount = "30", type = BudgetEntry.Type.OUTCOME)
+        )
+        val detail = BudgetDetail(entries = entries)
+        val repository = FakeBudgetDetailRepository()
+        repository.cachedDetail = detail
+
+        val viewModel = BudgetDetailViewModel(repository)
+        val filter = BudgetEntryFilter.ByType(BudgetEntry.Type.INCOME)
+        viewModel.sendEvent(BudgetDetailEvent.FilterEntries(filter))
+
+        kotlinx.coroutines.delay(100)
+
+        val state = viewModel.uiState.value
+        assertEquals(filter, state.filter)
+    }
+
+    @Test
+    fun `clearFilter removes filter from state`() = runTest {
+        val repository = FakeBudgetDetailRepository()
+        repository.cachedDetail = BudgetDetail(entries = emptyList())
+
+        val viewModel = BudgetDetailViewModel(repository)
+        viewModel.sendEvent(BudgetDetailEvent.ClearFilter)
+
+        kotlinx.coroutines.delay(100)
+
+        val state = viewModel.uiState.value
+        assertNull(state.filter)
+    }
+
+    @Test
+    fun `deleteBudget calls repository and sets goBack`() = runTest {
+        val budget = Budget(id = 42, name = "Test", amount = 100.0)
+        val repository = FakeBudgetDetailRepository()
+        repository.cachedDetail = BudgetDetail(budget = budget)
+
+        val viewModel = BudgetDetailViewModel(repository)
+        viewModel.sendEvent(BudgetDetailEvent.SetBudget(budget))
+        viewModel.sendEvent(BudgetDetailEvent.DeleteBudget)
+
+        kotlinx.coroutines.delay(100)
+
+        assertEquals(listOf(42), repository.deletedBudgetIds)
+        assertTrue(viewModel.uiState.value.goBack)
+    }
+
+    @Test
+    fun `deleteSelectedEntries deletes only selected entries`() = runTest {
+        val entries = listOf(
+            BudgetEntry(id = 1, budgetId = 1, amount = "50", isSelected = true),
+            BudgetEntry(id = 2, budgetId = 1, amount = "30", isSelected = false),
+            BudgetEntry(id = 3, budgetId = 1, amount = "20", isSelected = true)
+        )
+        val repository = FakeBudgetDetailRepository()
+        repository.cachedDetail = BudgetDetail(entries = entries)
+
+        val viewModel = BudgetDetailViewModel(repository)
+        viewModel.sendEvent(BudgetDetailEvent.DeleteSelectedEntries)
+
+        kotlinx.coroutines.delay(100)
+
+        assertEquals(1, repository.deletedEntryIds.size)
+        assertEquals(listOf(1, 3), repository.deletedEntryIds[0])
+    }
+
+    @Test
+    fun `showEntry sets entry in state`() = runTest {
+        val entry = BudgetEntry(id = 1, budgetId = 1, amount = "50")
+        val repository = FakeBudgetDetailRepository()
+        val viewModel = BudgetDetailViewModel(repository)
+
+        viewModel.sendEvent(BudgetDetailEvent.ShowEntry(entry))
+
+        assertEquals(entry, viewModel.uiState.value.showEntry)
+    }
+
+    @Test
+    fun `clearNavigation resets showEntry`() = runTest {
+        val entry = BudgetEntry(id = 1, budgetId = 1, amount = "50")
+        val repository = FakeBudgetDetailRepository()
+        val viewModel = BudgetDetailViewModel(repository)
+
+        viewModel.sendEvent(BudgetDetailEvent.ShowEntry(entry))
+        viewModel.sendEvent(BudgetDetailEvent.ClearNavigation)
+
+        assertNull(viewModel.uiState.value.showEntry)
+    }
+
+    @Test
+    fun `toggleBudgetModal sets modal visibility`() = runTest {
+        val repository = FakeBudgetDetailRepository()
+        val viewModel = BudgetDetailViewModel(repository)
+
+        viewModel.sendEvent(BudgetDetailEvent.ToggleBudgetModal(true))
+        assertTrue(viewModel.uiState.value.isBudgetModalVisible)
+
+        viewModel.sendEvent(BudgetDetailEvent.ToggleBudgetModal(false))
+        assertFalse(viewModel.uiState.value.isBudgetModalVisible)
+    }
+
+    @Test
+    fun `toggleDeleteBudgetModal sets modal visibility`() = runTest {
+        val repository = FakeBudgetDetailRepository()
+        val viewModel = BudgetDetailViewModel(repository)
+
+        viewModel.sendEvent(BudgetDetailEvent.ToggleDeleteBudgetModal(true))
+        assertTrue(viewModel.uiState.value.isDeleteBudgetModalVisible)
+
+        viewModel.sendEvent(BudgetDetailEvent.ToggleDeleteBudgetModal(false))
+        assertFalse(viewModel.uiState.value.isDeleteBudgetModalVisible)
+    }
+
+    @Test
+    fun `toggleDeleteEntriesModal sets modal visibility`() = runTest {
+        val repository = FakeBudgetDetailRepository()
+        val viewModel = BudgetDetailViewModel(repository)
+
+        viewModel.sendEvent(BudgetDetailEvent.ToggleDeleteEntriesModal(true))
+        assertTrue(viewModel.uiState.value.isDeleteEntriesModalVisible)
+
+        viewModel.sendEvent(BudgetDetailEvent.ToggleDeleteEntriesModal(false))
+        assertFalse(viewModel.uiState.value.isDeleteEntriesModalVisible)
+    }
+
+    @Test
+    fun `toggleFilterModal sets modal visibility`() = runTest {
+        val repository = FakeBudgetDetailRepository()
+        val viewModel = BudgetDetailViewModel(repository)
+
+        viewModel.sendEvent(BudgetDetailEvent.ToggleFilterModal(true))
+        assertTrue(viewModel.uiState.value.isFilterModalVisible)
+
+        viewModel.sendEvent(BudgetDetailEvent.ToggleFilterModal(false))
+        assertFalse(viewModel.uiState.value.isFilterModalVisible)
+    }
+
+    @Test
+    fun `toggleSelectionState activates selection mode`() = runTest {
+        val repository = FakeBudgetDetailRepository()
+        val viewModel = BudgetDetailViewModel(repository)
+
+        viewModel.sendEvent(BudgetDetailEvent.ToggleSelectionState(true))
+        assertTrue(viewModel.uiState.value.isSelectionActive)
+
+        viewModel.sendEvent(BudgetDetailEvent.ToggleSelectionState(false))
+        assertFalse(viewModel.uiState.value.isSelectionActive)
+    }
+
+    @Test
+    fun `toggleAllEntriesSelection selects all entries`() = runTest {
+        val entries = listOf(
+            BudgetEntry(id = 1, budgetId = 1, amount = "50", isSelected = false),
+            BudgetEntry(id = 2, budgetId = 1, amount = "30", isSelected = false)
+        )
+        val repository = FakeBudgetDetailRepository()
+        repository.cachedDetail = BudgetDetail(entries = entries)
+
+        val viewModel = BudgetDetailViewModel(repository)
+        viewModel.sendEvent(BudgetDetailEvent.GetBudgetDetail)
+        kotlinx.coroutines.delay(100)
+
+        viewModel.sendEvent(BudgetDetailEvent.ToggleAllEntriesSelection(true))
+
+        val state = viewModel.uiState.value
+        assertTrue(state.budgetDetail.entries.all { it.isSelected })
+    }
+
+    @Test
+    fun `toggleAllEntriesSelection deselects all entries`() = runTest {
+        val entries = listOf(
+            BudgetEntry(id = 1, budgetId = 1, amount = "50", isSelected = true),
+            BudgetEntry(id = 2, budgetId = 1, amount = "30", isSelected = true)
+        )
+        val repository = FakeBudgetDetailRepository()
+        repository.cachedDetail = BudgetDetail(entries = entries)
+
+        val viewModel = BudgetDetailViewModel(repository)
+        viewModel.sendEvent(BudgetDetailEvent.GetBudgetDetail)
+        kotlinx.coroutines.delay(100)
+
+        viewModel.sendEvent(BudgetDetailEvent.ToggleAllEntriesSelection(false))
+
+        val state = viewModel.uiState.value
+        assertTrue(state.budgetDetail.entries.none { it.isSelected })
+    }
+
+    @Test
+    fun `toggleSelectEntry toggles individual entry selection`() = runTest {
+        val entries = listOf(
+            BudgetEntry(id = 1, budgetId = 1, amount = "50", isSelected = false),
+            BudgetEntry(id = 2, budgetId = 1, amount = "30", isSelected = false)
+        )
+        val repository = FakeBudgetDetailRepository()
+        repository.cachedDetail = BudgetDetail(entries = entries)
+
+        val viewModel = BudgetDetailViewModel(repository)
+        viewModel.sendEvent(BudgetDetailEvent.GetBudgetDetail)
+        kotlinx.coroutines.delay(100)
+
+        viewModel.sendEvent(BudgetDetailEvent.ToggleSelectEntry(index = 0, isSelected = true))
+
+        val state = viewModel.uiState.value
+        assertTrue(state.budgetDetail.entries[0].isSelected)
+        assertFalse(state.budgetDetail.entries[1].isSelected)
+    }
+
+    @Test
+    fun `sortList cycles through sort orders`() = runTest {
+        val entries = listOf(
+            BudgetEntry(id = 3, budgetId = 1, amount = "100", type = BudgetEntry.Type.INCOME),
+            BudgetEntry(id = 2, budgetId = 1, amount = "50", type = BudgetEntry.Type.OUTCOME),
+            BudgetEntry(id = 1, budgetId = 1, amount = "75", type = BudgetEntry.Type.INCOME)
+        )
+        val repository = FakeBudgetDetailRepository()
+        repository.cachedDetail = BudgetDetail(entries = entries)
+
+        val viewModel = BudgetDetailViewModel(repository)
+        viewModel.sendEvent(BudgetDetailEvent.GetBudgetDetail)
+        kotlinx.coroutines.delay(100)
+
+        // First sort: AMOUNT_ASCENDANT
+        viewModel.sendEvent(BudgetDetailEvent.SortList)
+        assertEquals(BudgetDetailState.ListOrder.AMOUNT_ASCENDANT, viewModel.uiState.value.listOrder)
+
+        // Second sort: AMOUNT_DESCENDANT
+        viewModel.sendEvent(BudgetDetailEvent.SortList)
+        assertEquals(BudgetDetailState.ListOrder.AMOUNT_DESCENDANT, viewModel.uiState.value.listOrder)
+
+        // Third sort: DEFAULT
+        viewModel.sendEvent(BudgetDetailEvent.SortList)
+        assertEquals(BudgetDetailState.ListOrder.DEFAULT, viewModel.uiState.value.listOrder)
+    }
+
+    @Test
+    fun `deactivating selection deselects all entries`() = runTest {
+        val entries = listOf(
+            BudgetEntry(id = 1, budgetId = 1, amount = "50", isSelected = true),
+            BudgetEntry(id = 2, budgetId = 1, amount = "30", isSelected = true)
+        )
+        val repository = FakeBudgetDetailRepository()
+        repository.cachedDetail = BudgetDetail(entries = entries)
+
+        val viewModel = BudgetDetailViewModel(repository)
+        viewModel.sendEvent(BudgetDetailEvent.GetBudgetDetail)
+        kotlinx.coroutines.delay(100)
+
+        viewModel.sendEvent(BudgetDetailEvent.ToggleSelectionState(false))
+
+        val state = viewModel.uiState.value
+        assertTrue(state.budgetDetail.entries.none { it.isSelected })
+    }
+}

--- a/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/budgetDetail/BudgetDetailViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/budgetDetail/BudgetDetailViewModelTest.kt
@@ -47,10 +47,10 @@ class BudgetDetailViewModelTest {
         val budget = Budget(id = 1, name = "Test", amount = 100.0)
         val detail = BudgetDetail(budget = budget, entries = entries)
 
-        val repository: IBudgetDetailRepository = FakeBudgetDetailRepository()
-        repository.cachedDetail = detail
+        val fakeRepository = FakeBudgetDetailRepository()
+        fakeRepository.cachedDetail = detail
 
-        val viewModel = BudgetDetailViewModel(repository)
+        val viewModel = BudgetDetailViewModel(fakeRepository)
         viewModel.sendEvent(BudgetDetailEvent.SetBudget(budget))
         viewModel.sendEvent(BudgetDetailEvent.GetBudgetDetail)
 
@@ -63,14 +63,14 @@ class BudgetDetailViewModelTest {
 
     @Test
     fun `updateBudgetAmount calls repository`() = runTest {
-        val repository: IBudgetDetailRepository = FakeBudgetDetailRepository()
-        val viewModel = BudgetDetailViewModel(repository)
+        val fakeRepository = FakeBudgetDetailRepository()
+        val viewModel = BudgetDetailViewModel(fakeRepository)
 
         viewModel.sendEvent(BudgetDetailEvent.UpdateBudgetAmount(500.0))
 
         kotlinx.coroutines.delay(100)
 
-        assertEquals(listOf(500.0), repository.updatedAmounts)
+        assertEquals(listOf(500.0), fakeRepository.updatedAmounts)
     }
 
     @Test
@@ -80,10 +80,10 @@ class BudgetDetailViewModelTest {
             BudgetEntry(id = 2, budgetId = 1, amount = "30", type = BudgetEntry.Type.OUTCOME)
         )
         val detail = BudgetDetail(entries = entries)
-        val repository: IBudgetDetailRepository = FakeBudgetDetailRepository()
-        repository.cachedDetail = detail
+        val fakeRepository = FakeBudgetDetailRepository()
+        fakeRepository.cachedDetail = detail
 
-        val viewModel = BudgetDetailViewModel(repository)
+        val viewModel = BudgetDetailViewModel(fakeRepository)
         val filter = BudgetEntryFilter.ByType(BudgetEntry.Type.INCOME)
         viewModel.sendEvent(BudgetDetailEvent.FilterEntries(filter))
 
@@ -95,10 +95,10 @@ class BudgetDetailViewModelTest {
 
     @Test
     fun `clearFilter removes filter from state`() = runTest {
-        val repository: IBudgetDetailRepository = FakeBudgetDetailRepository()
-        repository.cachedDetail = BudgetDetail(entries = emptyList())
+        val fakeRepository = FakeBudgetDetailRepository()
+        fakeRepository.cachedDetail = BudgetDetail(entries = emptyList())
 
-        val viewModel = BudgetDetailViewModel(repository)
+        val viewModel = BudgetDetailViewModel(fakeRepository)
         viewModel.sendEvent(BudgetDetailEvent.ClearFilter)
 
         kotlinx.coroutines.delay(100)
@@ -110,16 +110,16 @@ class BudgetDetailViewModelTest {
     @Test
     fun `deleteBudget calls repository and sets goBack`() = runTest {
         val budget = Budget(id = 42, name = "Test", amount = 100.0)
-        val repository: IBudgetDetailRepository = FakeBudgetDetailRepository()
-        repository.cachedDetail = BudgetDetail(budget = budget)
+        val fakeRepository = FakeBudgetDetailRepository()
+        fakeRepository.cachedDetail = BudgetDetail(budget = budget)
 
-        val viewModel = BudgetDetailViewModel(repository)
+        val viewModel = BudgetDetailViewModel(fakeRepository)
         viewModel.sendEvent(BudgetDetailEvent.SetBudget(budget))
         viewModel.sendEvent(BudgetDetailEvent.DeleteBudget)
 
         kotlinx.coroutines.delay(100)
 
-        assertEquals(listOf(42), repository.deletedBudgetIds)
+        assertEquals(listOf(42), fakeRepository.deletedBudgetIds)
         assertTrue(viewModel.uiState.value.goBack)
     }
 
@@ -130,16 +130,16 @@ class BudgetDetailViewModelTest {
             BudgetEntry(id = 2, budgetId = 1, amount = "30", isSelected = false),
             BudgetEntry(id = 3, budgetId = 1, amount = "20", isSelected = true)
         )
-        val repository: IBudgetDetailRepository = FakeBudgetDetailRepository()
-        repository.cachedDetail = BudgetDetail(entries = entries)
+        val fakeRepository = FakeBudgetDetailRepository()
+        fakeRepository.cachedDetail = BudgetDetail(entries = entries)
 
-        val viewModel = BudgetDetailViewModel(repository)
+        val viewModel = BudgetDetailViewModel(fakeRepository)
         viewModel.sendEvent(BudgetDetailEvent.DeleteSelectedEntries)
 
         kotlinx.coroutines.delay(100)
 
-        assertEquals(1, repository.deletedEntryIds.size)
-        assertEquals(listOf(1, 3), repository.deletedEntryIds[0])
+        assertEquals(1, fakeRepository.deletedEntryIds.size)
+        assertEquals(listOf(1, 3), fakeRepository.deletedEntryIds[0])
     }
 
     @Test
@@ -231,10 +231,10 @@ class BudgetDetailViewModelTest {
             BudgetEntry(id = 1, budgetId = 1, amount = "50", isSelected = false),
             BudgetEntry(id = 2, budgetId = 1, amount = "30", isSelected = false)
         )
-        val repository: IBudgetDetailRepository = FakeBudgetDetailRepository()
-        repository.cachedDetail = BudgetDetail(entries = entries)
+        val fakeRepository = FakeBudgetDetailRepository()
+        fakeRepository.cachedDetail = BudgetDetail(entries = entries)
 
-        val viewModel = BudgetDetailViewModel(repository)
+        val viewModel = BudgetDetailViewModel(fakeRepository)
         viewModel.sendEvent(BudgetDetailEvent.GetBudgetDetail)
         kotlinx.coroutines.delay(100)
 
@@ -250,10 +250,10 @@ class BudgetDetailViewModelTest {
             BudgetEntry(id = 1, budgetId = 1, amount = "50", isSelected = true),
             BudgetEntry(id = 2, budgetId = 1, amount = "30", isSelected = true)
         )
-        val repository: IBudgetDetailRepository = FakeBudgetDetailRepository()
-        repository.cachedDetail = BudgetDetail(entries = entries)
+        val fakeRepository = FakeBudgetDetailRepository()
+        fakeRepository.cachedDetail = BudgetDetail(entries = entries)
 
-        val viewModel = BudgetDetailViewModel(repository)
+        val viewModel = BudgetDetailViewModel(fakeRepository)
         viewModel.sendEvent(BudgetDetailEvent.GetBudgetDetail)
         kotlinx.coroutines.delay(100)
 
@@ -269,10 +269,10 @@ class BudgetDetailViewModelTest {
             BudgetEntry(id = 1, budgetId = 1, amount = "50", isSelected = false),
             BudgetEntry(id = 2, budgetId = 1, amount = "30", isSelected = false)
         )
-        val repository: IBudgetDetailRepository = FakeBudgetDetailRepository()
-        repository.cachedDetail = BudgetDetail(entries = entries)
+        val fakeRepository = FakeBudgetDetailRepository()
+        fakeRepository.cachedDetail = BudgetDetail(entries = entries)
 
-        val viewModel = BudgetDetailViewModel(repository)
+        val viewModel = BudgetDetailViewModel(fakeRepository)
         viewModel.sendEvent(BudgetDetailEvent.GetBudgetDetail)
         kotlinx.coroutines.delay(100)
 
@@ -290,10 +290,10 @@ class BudgetDetailViewModelTest {
             BudgetEntry(id = 2, budgetId = 1, amount = "50", type = BudgetEntry.Type.OUTCOME),
             BudgetEntry(id = 1, budgetId = 1, amount = "75", type = BudgetEntry.Type.INCOME)
         )
-        val repository: IBudgetDetailRepository = FakeBudgetDetailRepository()
-        repository.cachedDetail = BudgetDetail(entries = entries)
+        val fakeRepository = FakeBudgetDetailRepository()
+        fakeRepository.cachedDetail = BudgetDetail(entries = entries)
 
-        val viewModel = BudgetDetailViewModel(repository)
+        val viewModel = BudgetDetailViewModel(fakeRepository)
         viewModel.sendEvent(BudgetDetailEvent.GetBudgetDetail)
         kotlinx.coroutines.delay(100)
 
@@ -316,10 +316,10 @@ class BudgetDetailViewModelTest {
             BudgetEntry(id = 1, budgetId = 1, amount = "50", isSelected = true),
             BudgetEntry(id = 2, budgetId = 1, amount = "30", isSelected = true)
         )
-        val repository: IBudgetDetailRepository = FakeBudgetDetailRepository()
-        repository.cachedDetail = BudgetDetail(entries = entries)
+        val fakeRepository = FakeBudgetDetailRepository()
+        fakeRepository.cachedDetail = BudgetDetail(entries = entries)
 
-        val viewModel = BudgetDetailViewModel(repository)
+        val viewModel = BudgetDetailViewModel(fakeRepository)
         viewModel.sendEvent(BudgetDetailEvent.GetBudgetDetail)
         kotlinx.coroutines.delay(100)
 

--- a/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/budgetDetail/BudgetDetailViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/budgetDetail/BudgetDetailViewModelTest.kt
@@ -84,7 +84,7 @@ class BudgetDetailViewModelTest {
         fakeRepository.cachedDetail = detail
 
         val viewModel = BudgetDetailViewModel(fakeRepository)
-        val filter = BudgetEntryFilter.ByType(BudgetEntry.Type.INCOME)
+        val filter = BudgetEntryFilter(type = BudgetEntry.Type.INCOME)
         viewModel.sendEvent(BudgetDetailEvent.FilterEntries(filter))
 
         kotlinx.coroutines.delay(100)

--- a/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/budgetDetail/BudgetDetailViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/budgetDetail/BudgetDetailViewModelTest.kt
@@ -2,13 +2,11 @@ package com.meneses.budgethunter.budgetDetail
 
 import com.meneses.budgethunter.budgetDetail.application.BudgetDetailEvent
 import com.meneses.budgethunter.budgetDetail.application.BudgetDetailState
-import com.meneses.budgethunter.budgetDetail.data.BudgetDetailRepository
 import com.meneses.budgethunter.budgetDetail.domain.BudgetDetail
 import com.meneses.budgethunter.budgetEntry.domain.BudgetEntry
 import com.meneses.budgethunter.budgetEntry.domain.BudgetEntryFilter
 import com.meneses.budgethunter.budgetList.domain.Budget
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flowOf
+import com.meneses.budgethunter.fakes.repository.FakeBudgetDetailRepository
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -17,43 +15,6 @@ import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class BudgetDetailViewModelTest {
-
-    private class FakeBudgetDetailRepository : BudgetDetailRepository {
-        var cachedDetail = BudgetDetail()
-        val deletedBudgetIds = mutableListOf<Int>()
-        val deletedEntryIds = mutableListOf<List<Int>>()
-        val updatedAmounts = mutableListOf<Double>()
-
-        override suspend fun getBudgetDetailById(budgetId: Int): Flow<BudgetDetail> {
-            return flowOf(cachedDetail)
-        }
-
-        override suspend fun getCachedDetail(): BudgetDetail = cachedDetail
-
-        override suspend fun getAllFilteredBy(filter: BudgetEntryFilter): BudgetDetail {
-            return cachedDetail.copy(
-                entries = cachedDetail.entries.filter {
-                    when (filter) {
-                        is BudgetEntryFilter.ByCategory -> it.category == filter.category
-                        is BudgetEntryFilter.ByType -> it.type == filter.type
-                        else -> true
-                    }
-                }
-            )
-        }
-
-        override suspend fun deleteBudget(budgetId: Int) {
-            deletedBudgetIds.add(budgetId)
-        }
-
-        override suspend fun deleteEntriesByIds(ids: List<Int>) {
-            deletedEntryIds.add(ids)
-        }
-
-        override suspend fun updateBudgetAmount(amount: Double) {
-            updatedAmounts.add(amount)
-        }
-    }
 
     @Test
     fun `initial state is loading`() = runTest {

--- a/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/budgetDetail/BudgetDetailViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/budgetDetail/BudgetDetailViewModelTest.kt
@@ -18,7 +18,7 @@ class BudgetDetailViewModelTest {
 
     @Test
     fun `initial state is loading`() = runTest {
-        val repository = FakeBudgetDetailRepository()
+        val repository: IBudgetDetailRepository = FakeBudgetDetailRepository()
         val viewModel = BudgetDetailViewModel(repository)
 
         val state = viewModel.uiState.value
@@ -27,7 +27,7 @@ class BudgetDetailViewModelTest {
 
     @Test
     fun `setBudget updates budget in state`() = runTest {
-        val repository = FakeBudgetDetailRepository()
+        val repository: IBudgetDetailRepository = FakeBudgetDetailRepository()
         val viewModel = BudgetDetailViewModel(repository)
 
         val budget = Budget(id = 1, name = "Test Budget", amount = 100.0)
@@ -46,7 +46,7 @@ class BudgetDetailViewModelTest {
         val budget = Budget(id = 1, name = "Test", amount = 100.0)
         val detail = BudgetDetail(budget = budget, entries = entries)
 
-        val repository = FakeBudgetDetailRepository()
+        val repository: IBudgetDetailRepository = FakeBudgetDetailRepository()
         repository.cachedDetail = detail
 
         val viewModel = BudgetDetailViewModel(repository)
@@ -62,7 +62,7 @@ class BudgetDetailViewModelTest {
 
     @Test
     fun `updateBudgetAmount calls repository`() = runTest {
-        val repository = FakeBudgetDetailRepository()
+        val repository: IBudgetDetailRepository = FakeBudgetDetailRepository()
         val viewModel = BudgetDetailViewModel(repository)
 
         viewModel.sendEvent(BudgetDetailEvent.UpdateBudgetAmount(500.0))
@@ -79,7 +79,7 @@ class BudgetDetailViewModelTest {
             BudgetEntry(id = 2, budgetId = 1, amount = "30", type = BudgetEntry.Type.OUTCOME)
         )
         val detail = BudgetDetail(entries = entries)
-        val repository = FakeBudgetDetailRepository()
+        val repository: IBudgetDetailRepository = FakeBudgetDetailRepository()
         repository.cachedDetail = detail
 
         val viewModel = BudgetDetailViewModel(repository)
@@ -94,7 +94,7 @@ class BudgetDetailViewModelTest {
 
     @Test
     fun `clearFilter removes filter from state`() = runTest {
-        val repository = FakeBudgetDetailRepository()
+        val repository: IBudgetDetailRepository = FakeBudgetDetailRepository()
         repository.cachedDetail = BudgetDetail(entries = emptyList())
 
         val viewModel = BudgetDetailViewModel(repository)
@@ -109,7 +109,7 @@ class BudgetDetailViewModelTest {
     @Test
     fun `deleteBudget calls repository and sets goBack`() = runTest {
         val budget = Budget(id = 42, name = "Test", amount = 100.0)
-        val repository = FakeBudgetDetailRepository()
+        val repository: IBudgetDetailRepository = FakeBudgetDetailRepository()
         repository.cachedDetail = BudgetDetail(budget = budget)
 
         val viewModel = BudgetDetailViewModel(repository)
@@ -129,7 +129,7 @@ class BudgetDetailViewModelTest {
             BudgetEntry(id = 2, budgetId = 1, amount = "30", isSelected = false),
             BudgetEntry(id = 3, budgetId = 1, amount = "20", isSelected = true)
         )
-        val repository = FakeBudgetDetailRepository()
+        val repository: IBudgetDetailRepository = FakeBudgetDetailRepository()
         repository.cachedDetail = BudgetDetail(entries = entries)
 
         val viewModel = BudgetDetailViewModel(repository)
@@ -144,7 +144,7 @@ class BudgetDetailViewModelTest {
     @Test
     fun `showEntry sets entry in state`() = runTest {
         val entry = BudgetEntry(id = 1, budgetId = 1, amount = "50")
-        val repository = FakeBudgetDetailRepository()
+        val repository: IBudgetDetailRepository = FakeBudgetDetailRepository()
         val viewModel = BudgetDetailViewModel(repository)
 
         viewModel.sendEvent(BudgetDetailEvent.ShowEntry(entry))
@@ -155,7 +155,7 @@ class BudgetDetailViewModelTest {
     @Test
     fun `clearNavigation resets showEntry`() = runTest {
         val entry = BudgetEntry(id = 1, budgetId = 1, amount = "50")
-        val repository = FakeBudgetDetailRepository()
+        val repository: IBudgetDetailRepository = FakeBudgetDetailRepository()
         val viewModel = BudgetDetailViewModel(repository)
 
         viewModel.sendEvent(BudgetDetailEvent.ShowEntry(entry))
@@ -166,7 +166,7 @@ class BudgetDetailViewModelTest {
 
     @Test
     fun `toggleBudgetModal sets modal visibility`() = runTest {
-        val repository = FakeBudgetDetailRepository()
+        val repository: IBudgetDetailRepository = FakeBudgetDetailRepository()
         val viewModel = BudgetDetailViewModel(repository)
 
         viewModel.sendEvent(BudgetDetailEvent.ToggleBudgetModal(true))
@@ -178,7 +178,7 @@ class BudgetDetailViewModelTest {
 
     @Test
     fun `toggleDeleteBudgetModal sets modal visibility`() = runTest {
-        val repository = FakeBudgetDetailRepository()
+        val repository: IBudgetDetailRepository = FakeBudgetDetailRepository()
         val viewModel = BudgetDetailViewModel(repository)
 
         viewModel.sendEvent(BudgetDetailEvent.ToggleDeleteBudgetModal(true))
@@ -190,7 +190,7 @@ class BudgetDetailViewModelTest {
 
     @Test
     fun `toggleDeleteEntriesModal sets modal visibility`() = runTest {
-        val repository = FakeBudgetDetailRepository()
+        val repository: IBudgetDetailRepository = FakeBudgetDetailRepository()
         val viewModel = BudgetDetailViewModel(repository)
 
         viewModel.sendEvent(BudgetDetailEvent.ToggleDeleteEntriesModal(true))
@@ -202,7 +202,7 @@ class BudgetDetailViewModelTest {
 
     @Test
     fun `toggleFilterModal sets modal visibility`() = runTest {
-        val repository = FakeBudgetDetailRepository()
+        val repository: IBudgetDetailRepository = FakeBudgetDetailRepository()
         val viewModel = BudgetDetailViewModel(repository)
 
         viewModel.sendEvent(BudgetDetailEvent.ToggleFilterModal(true))
@@ -214,7 +214,7 @@ class BudgetDetailViewModelTest {
 
     @Test
     fun `toggleSelectionState activates selection mode`() = runTest {
-        val repository = FakeBudgetDetailRepository()
+        val repository: IBudgetDetailRepository = FakeBudgetDetailRepository()
         val viewModel = BudgetDetailViewModel(repository)
 
         viewModel.sendEvent(BudgetDetailEvent.ToggleSelectionState(true))
@@ -230,7 +230,7 @@ class BudgetDetailViewModelTest {
             BudgetEntry(id = 1, budgetId = 1, amount = "50", isSelected = false),
             BudgetEntry(id = 2, budgetId = 1, amount = "30", isSelected = false)
         )
-        val repository = FakeBudgetDetailRepository()
+        val repository: IBudgetDetailRepository = FakeBudgetDetailRepository()
         repository.cachedDetail = BudgetDetail(entries = entries)
 
         val viewModel = BudgetDetailViewModel(repository)
@@ -249,7 +249,7 @@ class BudgetDetailViewModelTest {
             BudgetEntry(id = 1, budgetId = 1, amount = "50", isSelected = true),
             BudgetEntry(id = 2, budgetId = 1, amount = "30", isSelected = true)
         )
-        val repository = FakeBudgetDetailRepository()
+        val repository: IBudgetDetailRepository = FakeBudgetDetailRepository()
         repository.cachedDetail = BudgetDetail(entries = entries)
 
         val viewModel = BudgetDetailViewModel(repository)
@@ -268,7 +268,7 @@ class BudgetDetailViewModelTest {
             BudgetEntry(id = 1, budgetId = 1, amount = "50", isSelected = false),
             BudgetEntry(id = 2, budgetId = 1, amount = "30", isSelected = false)
         )
-        val repository = FakeBudgetDetailRepository()
+        val repository: IBudgetDetailRepository = FakeBudgetDetailRepository()
         repository.cachedDetail = BudgetDetail(entries = entries)
 
         val viewModel = BudgetDetailViewModel(repository)
@@ -289,7 +289,7 @@ class BudgetDetailViewModelTest {
             BudgetEntry(id = 2, budgetId = 1, amount = "50", type = BudgetEntry.Type.OUTCOME),
             BudgetEntry(id = 1, budgetId = 1, amount = "75", type = BudgetEntry.Type.INCOME)
         )
-        val repository = FakeBudgetDetailRepository()
+        val repository: IBudgetDetailRepository = FakeBudgetDetailRepository()
         repository.cachedDetail = BudgetDetail(entries = entries)
 
         val viewModel = BudgetDetailViewModel(repository)
@@ -315,7 +315,7 @@ class BudgetDetailViewModelTest {
             BudgetEntry(id = 1, budgetId = 1, amount = "50", isSelected = true),
             BudgetEntry(id = 2, budgetId = 1, amount = "30", isSelected = true)
         )
-        val repository = FakeBudgetDetailRepository()
+        val repository: IBudgetDetailRepository = FakeBudgetDetailRepository()
         repository.cachedDetail = BudgetDetail(entries = entries)
 
         val viewModel = BudgetDetailViewModel(repository)

--- a/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/budgetDetail/BudgetDetailViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/budgetDetail/BudgetDetailViewModelTest.kt
@@ -2,6 +2,7 @@ package com.meneses.budgethunter.budgetDetail
 
 import com.meneses.budgethunter.budgetDetail.application.BudgetDetailEvent
 import com.meneses.budgethunter.budgetDetail.application.BudgetDetailState
+import com.meneses.budgethunter.budgetDetail.data.IBudgetDetailRepository
 import com.meneses.budgethunter.budgetDetail.domain.BudgetDetail
 import com.meneses.budgethunter.budgetEntry.domain.BudgetEntry
 import com.meneses.budgethunter.budgetEntry.domain.BudgetEntryFilter

--- a/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/budgetEntry/BudgetEntryViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/budgetEntry/BudgetEntryViewModelTest.kt
@@ -189,7 +189,13 @@ class BudgetEntryViewModelTest {
         val entry = BudgetEntry(id = 1, budgetId = 1, amount = "100")
 
         viewModel.sendEvent(BudgetEntryEvent.SetBudgetEntry(entry))
-        viewModel.sendEvent(BudgetEntryEvent.AttachInvoice(byteArrayOf(1, 2, 3)))
+        val fileData = com.meneses.budgethunter.commons.data.FileData(
+            data = byteArrayOf(1, 2, 3),
+            filename = "invoice.pdf",
+            mimeType = "application/pdf",
+            directory = "/tmp"
+        )
+        viewModel.sendEvent(BudgetEntryEvent.AttachInvoice(fileData))
 
         kotlinx.coroutines.delay(100)
 
@@ -210,7 +216,13 @@ class BudgetEntryViewModelTest {
         val entry = BudgetEntry(id = 1, budgetId = 1, amount = "100")
 
         viewModel.sendEvent(BudgetEntryEvent.SetBudgetEntry(entry))
-        viewModel.sendEvent(BudgetEntryEvent.AttachInvoice(byteArrayOf(1, 2, 3)))
+        val fileData = com.meneses.budgethunter.commons.data.FileData(
+            data = byteArrayOf(1, 2, 3),
+            filename = "invoice.pdf",
+            mimeType = "application/pdf",
+            directory = "/tmp"
+        )
+        viewModel.sendEvent(BudgetEntryEvent.AttachInvoice(fileData))
 
         kotlinx.coroutines.delay(100)
 

--- a/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/budgetEntry/BudgetEntryViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/budgetEntry/BudgetEntryViewModelTest.kt
@@ -11,6 +11,15 @@ import com.meneses.budgethunter.commons.platform.CameraManager
 import com.meneses.budgethunter.commons.platform.FilePickerManager
 import com.meneses.budgethunter.commons.platform.NotificationManager
 import com.meneses.budgethunter.commons.platform.ShareManager
+import com.meneses.budgethunter.fakes.manager.FakeCameraManager
+import com.meneses.budgethunter.fakes.manager.FakeFileManager
+import com.meneses.budgethunter.fakes.manager.FakeFilePickerManager
+import com.meneses.budgethunter.fakes.manager.FakeNotificationManager
+import com.meneses.budgethunter.fakes.manager.FakePreferencesManager
+import com.meneses.budgethunter.fakes.manager.FakeShareManager
+import com.meneses.budgethunter.fakes.repository.FakeBudgetEntryRepository
+import com.meneses.budgethunter.fakes.usecase.FakeCreateBudgetEntryFromImageUseCase
+import com.meneses.budgethunter.fakes.usecase.FakeValidateFilePathUseCase
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -20,110 +29,6 @@ import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class BudgetEntryViewModelTest {
-
-    private class FakeBudgetEntryRepository : BudgetEntryRepository {
-        val createdEntries = mutableListOf<BudgetEntry>()
-        val updatedEntries = mutableListOf<BudgetEntry>()
-
-        override suspend fun create(budgetEntry: BudgetEntry) {
-            createdEntries.add(budgetEntry)
-        }
-
-        override suspend fun update(budgetEntry: BudgetEntry) {
-            updatedEntries.add(budgetEntry)
-        }
-    }
-
-    private class FakeCreateBudgetEntryFromImageUseCase : CreateBudgetEntryFromImageUseCase(null!!, null!!) {
-        var processedEntry: BudgetEntry? = null
-
-        override suspend fun execute(imageUri: String, budgetEntry: BudgetEntry): BudgetEntry {
-            return processedEntry ?: budgetEntry.copy(description = "AI Processed")
-        }
-    }
-
-    private class FakeValidateFilePathUseCase : ValidateFilePathUseCase(null!!) {
-        var validPath: String? = "/valid/path.pdf"
-
-        override suspend fun execute(filePath: String): String? = validPath
-    }
-
-    private class FakePreferencesManager : PreferencesManager {
-        var aiEnabled = false
-
-        override suspend fun isAiProcessingEnabled(): Boolean = aiEnabled
-        override suspend fun setAiProcessingEnabled(enabled: Boolean) {
-            aiEnabled = enabled
-        }
-
-        override suspend fun isSmsReadingEnabled(): Boolean = false
-        override suspend fun setSmsReadingEnabled(enabled: Boolean) {}
-        override suspend fun getDefaultBudgetId(): Int = -1
-        override suspend fun setDefaultBudgetId(budgetId: Int) {}
-        override suspend fun getSelectedBankIds(): Set<String> = emptySet()
-        override suspend fun setSelectedBankIds(bankIds: Set<String>) {}
-    }
-
-    private class FakeFileManager : FileManager {
-        val savedFiles = mutableListOf<ByteArray>()
-        val deletedFiles = mutableListOf<String>()
-
-        override suspend fun saveFile(fileData: ByteArray): String {
-            savedFiles.add(fileData)
-            return "/saved/file_${savedFiles.size}.pdf"
-        }
-
-        override fun deleteFile(filePath: String) {
-            deletedFiles.add(filePath)
-        }
-
-        override fun createUri(filePath: String): String = "file://$filePath"
-    }
-
-    private class FakeCameraManager : CameraManager {
-        var callback: ((ByteArray?) -> Unit)? = null
-
-        override fun takePhoto(onResult: (ByteArray?) -> Unit) {
-            callback = onResult
-        }
-
-        fun simulatePhotoTaken(data: ByteArray?) {
-            callback?.invoke(data)
-        }
-    }
-
-    private class FakeFilePickerManager : FilePickerManager {
-        var callback: ((ByteArray?) -> Unit)? = null
-
-        override fun pickFile(onResult: (ByteArray?) -> Unit) {
-            callback = onResult
-        }
-
-        fun simulateFilePicked(data: ByteArray?) {
-            callback?.invoke(data)
-        }
-    }
-
-    private class FakeShareManager : ShareManager {
-        val sharedFiles = mutableListOf<String>()
-
-        override suspend fun shareFile(filePath: String) {
-            sharedFiles.add(filePath)
-        }
-    }
-
-    private class FakeNotificationManager : NotificationManager {
-        val notifications = mutableListOf<Pair<String, String>>()
-        val toasts = mutableListOf<String>()
-
-        override fun showNotification(title: String, message: String) {
-            notifications.add(title to message)
-        }
-
-        override fun showToast(message: String) {
-            toasts.add(message)
-        }
-    }
 
     private fun createViewModel(
         repository: BudgetEntryRepository = FakeBudgetEntryRepository(),

--- a/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/budgetEntry/BudgetEntryViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/budgetEntry/BudgetEntryViewModelTest.kt
@@ -1,12 +1,12 @@
 package com.meneses.budgethunter.budgetEntry
 
 import com.meneses.budgethunter.budgetEntry.application.BudgetEntryEvent
-import com.meneses.budgethunter.budgetEntry.application.CreateBudgetEntryFromImageUseCase
-import com.meneses.budgethunter.budgetEntry.data.BudgetEntryRepository
+import com.meneses.budgethunter.budgetEntry.application.ICreateBudgetEntryFromImageUseCase
+import com.meneses.budgethunter.budgetEntry.data.IBudgetEntryRepository
 import com.meneses.budgethunter.budgetEntry.domain.BudgetEntry
-import com.meneses.budgethunter.commons.application.ValidateFilePathUseCase
-import com.meneses.budgethunter.commons.data.FileManager
-import com.meneses.budgethunter.commons.data.PreferencesManager
+import com.meneses.budgethunter.commons.application.IValidateFilePathUseCase
+import com.meneses.budgethunter.commons.data.IFileManager
+import com.meneses.budgethunter.commons.data.IPreferencesManager
 import com.meneses.budgethunter.commons.platform.CameraManager
 import com.meneses.budgethunter.commons.platform.FilePickerManager
 import com.meneses.budgethunter.commons.platform.NotificationManager

--- a/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/budgetEntry/BudgetEntryViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/budgetEntry/BudgetEntryViewModelTest.kt
@@ -31,11 +31,11 @@ import kotlin.test.assertTrue
 class BudgetEntryViewModelTest {
 
     private fun createViewModel(
-        repository: BudgetEntryRepository = FakeBudgetEntryRepository(),
-        createUseCase: CreateBudgetEntryFromImageUseCase = FakeCreateBudgetEntryFromImageUseCase(),
-        validateUseCase: ValidateFilePathUseCase = FakeValidateFilePathUseCase(),
-        preferences: PreferencesManager = FakePreferencesManager(),
-        fileManager: FileManager = FakeFileManager(),
+        repository: IBudgetEntryRepository = FakeBudgetEntryRepository(),
+        createUseCase: ICreateBudgetEntryFromImageUseCase = FakeCreateBudgetEntryFromImageUseCase(),
+        validateUseCase: IValidateFilePathUseCase = FakeValidateFilePathUseCase(),
+        preferences: IPreferencesManager = FakePreferencesManager(),
+        fileManager: IFileManager = FakeFileManager(),
         cameraManager: CameraManager = FakeCameraManager(),
         filePickerManager: FilePickerManager = FakeFilePickerManager(),
         shareManager: ShareManager = FakeShareManager(),

--- a/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/budgetEntry/BudgetEntryViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/budgetEntry/BudgetEntryViewModelTest.kt
@@ -1,0 +1,469 @@
+package com.meneses.budgethunter.budgetEntry
+
+import com.meneses.budgethunter.budgetEntry.application.BudgetEntryEvent
+import com.meneses.budgethunter.budgetEntry.application.CreateBudgetEntryFromImageUseCase
+import com.meneses.budgethunter.budgetEntry.data.BudgetEntryRepository
+import com.meneses.budgethunter.budgetEntry.domain.BudgetEntry
+import com.meneses.budgethunter.commons.application.ValidateFilePathUseCase
+import com.meneses.budgethunter.commons.data.FileManager
+import com.meneses.budgethunter.commons.data.PreferencesManager
+import com.meneses.budgethunter.commons.platform.CameraManager
+import com.meneses.budgethunter.commons.platform.FilePickerManager
+import com.meneses.budgethunter.commons.platform.NotificationManager
+import com.meneses.budgethunter.commons.platform.ShareManager
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class BudgetEntryViewModelTest {
+
+    private class FakeBudgetEntryRepository : BudgetEntryRepository {
+        val createdEntries = mutableListOf<BudgetEntry>()
+        val updatedEntries = mutableListOf<BudgetEntry>()
+
+        override suspend fun create(budgetEntry: BudgetEntry) {
+            createdEntries.add(budgetEntry)
+        }
+
+        override suspend fun update(budgetEntry: BudgetEntry) {
+            updatedEntries.add(budgetEntry)
+        }
+    }
+
+    private class FakeCreateBudgetEntryFromImageUseCase : CreateBudgetEntryFromImageUseCase(null!!, null!!) {
+        var processedEntry: BudgetEntry? = null
+
+        override suspend fun execute(imageUri: String, budgetEntry: BudgetEntry): BudgetEntry {
+            return processedEntry ?: budgetEntry.copy(description = "AI Processed")
+        }
+    }
+
+    private class FakeValidateFilePathUseCase : ValidateFilePathUseCase(null!!) {
+        var validPath: String? = "/valid/path.pdf"
+
+        override suspend fun execute(filePath: String): String? = validPath
+    }
+
+    private class FakePreferencesManager : PreferencesManager {
+        var aiEnabled = false
+
+        override suspend fun isAiProcessingEnabled(): Boolean = aiEnabled
+        override suspend fun setAiProcessingEnabled(enabled: Boolean) {
+            aiEnabled = enabled
+        }
+
+        override suspend fun isSmsReadingEnabled(): Boolean = false
+        override suspend fun setSmsReadingEnabled(enabled: Boolean) {}
+        override suspend fun getDefaultBudgetId(): Int = -1
+        override suspend fun setDefaultBudgetId(budgetId: Int) {}
+        override suspend fun getSelectedBankIds(): Set<String> = emptySet()
+        override suspend fun setSelectedBankIds(bankIds: Set<String>) {}
+    }
+
+    private class FakeFileManager : FileManager {
+        val savedFiles = mutableListOf<ByteArray>()
+        val deletedFiles = mutableListOf<String>()
+
+        override suspend fun saveFile(fileData: ByteArray): String {
+            savedFiles.add(fileData)
+            return "/saved/file_${savedFiles.size}.pdf"
+        }
+
+        override fun deleteFile(filePath: String) {
+            deletedFiles.add(filePath)
+        }
+
+        override fun createUri(filePath: String): String = "file://$filePath"
+    }
+
+    private class FakeCameraManager : CameraManager {
+        var callback: ((ByteArray?) -> Unit)? = null
+
+        override fun takePhoto(onResult: (ByteArray?) -> Unit) {
+            callback = onResult
+        }
+
+        fun simulatePhotoTaken(data: ByteArray?) {
+            callback?.invoke(data)
+        }
+    }
+
+    private class FakeFilePickerManager : FilePickerManager {
+        var callback: ((ByteArray?) -> Unit)? = null
+
+        override fun pickFile(onResult: (ByteArray?) -> Unit) {
+            callback = onResult
+        }
+
+        fun simulateFilePicked(data: ByteArray?) {
+            callback?.invoke(data)
+        }
+    }
+
+    private class FakeShareManager : ShareManager {
+        val sharedFiles = mutableListOf<String>()
+
+        override suspend fun shareFile(filePath: String) {
+            sharedFiles.add(filePath)
+        }
+    }
+
+    private class FakeNotificationManager : NotificationManager {
+        val notifications = mutableListOf<Pair<String, String>>()
+        val toasts = mutableListOf<String>()
+
+        override fun showNotification(title: String, message: String) {
+            notifications.add(title to message)
+        }
+
+        override fun showToast(message: String) {
+            toasts.add(message)
+        }
+    }
+
+    private fun createViewModel(
+        repository: BudgetEntryRepository = FakeBudgetEntryRepository(),
+        createUseCase: CreateBudgetEntryFromImageUseCase = FakeCreateBudgetEntryFromImageUseCase(),
+        validateUseCase: ValidateFilePathUseCase = FakeValidateFilePathUseCase(),
+        preferences: PreferencesManager = FakePreferencesManager(),
+        fileManager: FileManager = FakeFileManager(),
+        cameraManager: CameraManager = FakeCameraManager(),
+        filePickerManager: FilePickerManager = FakeFilePickerManager(),
+        shareManager: ShareManager = FakeShareManager(),
+        notificationManager: NotificationManager = FakeNotificationManager()
+    ): BudgetEntryViewModel {
+        return BudgetEntryViewModel(
+            repository, createUseCase, validateUseCase, preferences,
+            fileManager, cameraManager, filePickerManager, shareManager, notificationManager
+        )
+    }
+
+    @Test
+    fun `initial state has null budget entry`() = runTest {
+        val viewModel = createViewModel()
+
+        val state = viewModel.uiState.value
+        assertNull(state.budgetEntry)
+        assertFalse(state.goBack)
+    }
+
+    @Test
+    fun `setBudgetEntry updates state`() = runTest {
+        val viewModel = createViewModel()
+        val entry = BudgetEntry(id = 1, budgetId = 1, amount = "100")
+
+        viewModel.sendEvent(BudgetEntryEvent.SetBudgetEntry(entry))
+
+        kotlinx.coroutines.delay(100)
+
+        val state = viewModel.uiState.value
+        assertEquals(entry, state.budgetEntry)
+    }
+
+    @Test
+    fun `saveBudgetEntry creates new entry when id is negative`() = runTest {
+        val repository = FakeBudgetEntryRepository()
+        val viewModel = createViewModel(repository = repository)
+        val entry = BudgetEntry(id = -1, budgetId = 1, amount = "100")
+
+        viewModel.sendEvent(BudgetEntryEvent.SetBudgetEntry(entry))
+        viewModel.sendEvent(BudgetEntryEvent.SaveBudgetEntry)
+
+        kotlinx.coroutines.delay(100)
+
+        assertEquals(1, repository.createdEntries.size)
+        assertEquals(0, repository.updatedEntries.size)
+        assertTrue(viewModel.uiState.value.goBack)
+    }
+
+    @Test
+    fun `saveBudgetEntry updates existing entry when id is positive`() = runTest {
+        val repository = FakeBudgetEntryRepository()
+        val viewModel = createViewModel(repository = repository)
+        val entry = BudgetEntry(id = 5, budgetId = 1, amount = "100")
+
+        viewModel.sendEvent(BudgetEntryEvent.SetBudgetEntry(entry))
+        viewModel.sendEvent(BudgetEntryEvent.SaveBudgetEntry)
+
+        kotlinx.coroutines.delay(100)
+
+        assertEquals(0, repository.createdEntries.size)
+        assertEquals(1, repository.updatedEntries.size)
+    }
+
+    @Test
+    fun `saveBudgetEntry shows error when amount is empty`() = runTest {
+        val viewModel = createViewModel()
+        val entry = BudgetEntry(id = 1, budgetId = 1, amount = "")
+
+        viewModel.sendEvent(BudgetEntryEvent.SetBudgetEntry(entry))
+        viewModel.sendEvent(BudgetEntryEvent.SaveBudgetEntry)
+
+        kotlinx.coroutines.delay(100)
+
+        val state = viewModel.uiState.value
+        assertNotNull(state.emptyAmountError)
+        assertFalse(state.goBack)
+    }
+
+    @Test
+    fun `goBack sets goBack flag`() = runTest {
+        val viewModel = createViewModel()
+
+        viewModel.sendEvent(BudgetEntryEvent.GoBack)
+
+        val state = viewModel.uiState.value
+        assertTrue(state.goBack)
+    }
+
+    @Test
+    fun `validateChanges shows discard modal when entry changed`() = runTest {
+        val viewModel = createViewModel()
+        val originalEntry = BudgetEntry(id = 1, budgetId = 1, amount = "100")
+        val modifiedEntry = BudgetEntry(id = 1, budgetId = 1, amount = "200")
+
+        viewModel.sendEvent(BudgetEntryEvent.SetBudgetEntry(originalEntry))
+        viewModel.sendEvent(BudgetEntryEvent.ValidateChanges(modifiedEntry))
+
+        val state = viewModel.uiState.value
+        assertTrue(state.isDiscardChangesModalVisible)
+    }
+
+    @Test
+    fun `validateChanges goes back when entry unchanged`() = runTest {
+        val viewModel = createViewModel()
+        val entry = BudgetEntry(id = 1, budgetId = 1, amount = "100")
+
+        viewModel.sendEvent(BudgetEntryEvent.SetBudgetEntry(entry))
+        viewModel.sendEvent(BudgetEntryEvent.ValidateChanges(entry))
+
+        val state = viewModel.uiState.value
+        assertTrue(state.goBack)
+        assertFalse(state.isDiscardChangesModalVisible)
+    }
+
+    @Test
+    fun `hideDiscardChangesModal hides modal`() = runTest {
+        val viewModel = createViewModel()
+
+        viewModel.sendEvent(BudgetEntryEvent.HideDiscardChangesModal)
+
+        assertFalse(viewModel.uiState.value.isDiscardChangesModalVisible)
+    }
+
+    @Test
+    fun `toggleAttachInvoiceModal toggles visibility`() = runTest {
+        val viewModel = createViewModel()
+
+        viewModel.sendEvent(BudgetEntryEvent.ToggleAttachInvoiceModal(true))
+        assertTrue(viewModel.uiState.value.isAttachInvoiceModalVisible)
+
+        viewModel.sendEvent(BudgetEntryEvent.ToggleAttachInvoiceModal(false))
+        assertFalse(viewModel.uiState.value.isAttachInvoiceModalVisible)
+    }
+
+    @Test
+    fun `toggleShowInvoiceModal toggles visibility`() = runTest {
+        val viewModel = createViewModel()
+
+        viewModel.sendEvent(BudgetEntryEvent.ToggleShowInvoiceModal(true))
+        assertTrue(viewModel.uiState.value.isShowInvoiceModalVisible)
+
+        viewModel.sendEvent(BudgetEntryEvent.ToggleShowInvoiceModal(false))
+        assertFalse(viewModel.uiState.value.isShowInvoiceModalVisible)
+    }
+
+    @Test
+    fun `attachInvoice saves file and updates entry`() = runTest {
+        val fileManager = FakeFileManager()
+        val viewModel = createViewModel(fileManager = fileManager)
+        val entry = BudgetEntry(id = 1, budgetId = 1, amount = "100")
+
+        viewModel.sendEvent(BudgetEntryEvent.SetBudgetEntry(entry))
+        viewModel.sendEvent(BudgetEntryEvent.AttachInvoice(byteArrayOf(1, 2, 3)))
+
+        kotlinx.coroutines.delay(100)
+
+        assertEquals(1, fileManager.savedFiles.size)
+        val state = viewModel.uiState.value
+        assertNotNull(state.budgetEntry?.invoice)
+    }
+
+    @Test
+    fun `attachInvoice processes with AI when enabled`() = runTest {
+        val preferences = FakePreferencesManager()
+        preferences.aiEnabled = true
+
+        val createUseCase = FakeCreateBudgetEntryFromImageUseCase()
+        createUseCase.processedEntry = BudgetEntry(id = 1, budgetId = 1, amount = "150", description = "AI Result")
+
+        val viewModel = createViewModel(preferences = preferences, createUseCase = createUseCase)
+        val entry = BudgetEntry(id = 1, budgetId = 1, amount = "100")
+
+        viewModel.sendEvent(BudgetEntryEvent.SetBudgetEntry(entry))
+        viewModel.sendEvent(BudgetEntryEvent.AttachInvoice(byteArrayOf(1, 2, 3)))
+
+        kotlinx.coroutines.delay(100)
+
+        val state = viewModel.uiState.value
+        assertEquals("AI Result", state.budgetEntry?.description)
+    }
+
+    @Test
+    fun `deleteAttachedInvoice removes invoice from entry`() = runTest {
+        val viewModel = createViewModel()
+        val entry = BudgetEntry(id = 1, budgetId = 1, amount = "100", invoice = "/path/to/invoice.pdf")
+
+        viewModel.sendEvent(BudgetEntryEvent.SetBudgetEntry(entry))
+        viewModel.sendEvent(BudgetEntryEvent.DeleteAttachedInvoice)
+
+        val state = viewModel.uiState.value
+        assertNull(state.budgetEntry?.invoice)
+    }
+
+    @Test
+    fun `discardChanges goes back`() = runTest {
+        val viewModel = createViewModel()
+
+        viewModel.sendEvent(BudgetEntryEvent.DiscardChanges)
+
+        assertTrue(viewModel.uiState.value.goBack)
+    }
+
+    @Test
+    fun `takePhoto opens camera`() = runTest {
+        val cameraManager = FakeCameraManager()
+        val viewModel = createViewModel(cameraManager = cameraManager)
+
+        viewModel.sendEvent(BudgetEntryEvent.TakePhoto)
+
+        assertNotNull(cameraManager.callback)
+    }
+
+    @Test
+    fun `takePhoto attaches photo when taken`() = runTest {
+        val cameraManager = FakeCameraManager()
+        val fileManager = FakeFileManager()
+        val viewModel = createViewModel(cameraManager = cameraManager, fileManager = fileManager)
+
+        val entry = BudgetEntry(id = 1, budgetId = 1, amount = "100")
+        viewModel.sendEvent(BudgetEntryEvent.SetBudgetEntry(entry))
+        viewModel.sendEvent(BudgetEntryEvent.TakePhoto)
+
+        cameraManager.simulatePhotoTaken(byteArrayOf(1, 2, 3))
+
+        kotlinx.coroutines.delay(100)
+
+        assertEquals(1, fileManager.savedFiles.size)
+    }
+
+    @Test
+    fun `pickFile opens file picker`() = runTest {
+        val filePickerManager = FakeFilePickerManager()
+        val viewModel = createViewModel(filePickerManager = filePickerManager)
+
+        viewModel.sendEvent(BudgetEntryEvent.PickFile)
+
+        assertTrue(viewModel.uiState.value.isOpeningFilePicker)
+        assertNotNull(filePickerManager.callback)
+    }
+
+    @Test
+    fun `pickFile attaches file when picked`() = runTest {
+        val filePickerManager = FakeFilePickerManager()
+        val fileManager = FakeFileManager()
+        val viewModel = createViewModel(filePickerManager = filePickerManager, fileManager = fileManager)
+
+        val entry = BudgetEntry(id = 1, budgetId = 1, amount = "100")
+        viewModel.sendEvent(BudgetEntryEvent.SetBudgetEntry(entry))
+        viewModel.sendEvent(BudgetEntryEvent.PickFile)
+
+        filePickerManager.simulateFilePicked(byteArrayOf(1, 2, 3))
+
+        kotlinx.coroutines.delay(100)
+
+        assertEquals(1, fileManager.savedFiles.size)
+        assertFalse(viewModel.uiState.value.isOpeningFilePicker)
+    }
+
+    @Test
+    fun `shareFile shares the file`() = runTest {
+        val shareManager = FakeShareManager()
+        val viewModel = createViewModel(shareManager = shareManager)
+
+        viewModel.sendEvent(BudgetEntryEvent.ShareFile("/path/to/file.pdf"))
+
+        kotlinx.coroutines.delay(600)
+
+        assertEquals(listOf("/path/to/file.pdf"), shareManager.sharedFiles)
+        assertFalse(viewModel.uiState.value.isSharingFile)
+    }
+
+    @Test
+    fun `showNotification shows error notification`() = runTest {
+        val notificationManager = FakeNotificationManager()
+        val viewModel = createViewModel(notificationManager = notificationManager)
+
+        viewModel.sendEvent(BudgetEntryEvent.ShowNotification("Error occurred", isError = true))
+
+        assertEquals(1, notificationManager.notifications.size)
+        assertEquals("Error" to "Error occurred", notificationManager.notifications[0])
+    }
+
+    @Test
+    fun `showNotification shows toast for non-error`() = runTest {
+        val notificationManager = FakeNotificationManager()
+        val viewModel = createViewModel(notificationManager = notificationManager)
+
+        viewModel.sendEvent(BudgetEntryEvent.ShowNotification("Success", isError = false))
+
+        assertEquals(listOf("Success"), notificationManager.toasts)
+    }
+
+    @Test
+    fun `updateInvoice shows attach modal and hides show modal`() = runTest {
+        val viewModel = createViewModel()
+
+        viewModel.sendEvent(BudgetEntryEvent.ToggleShowInvoiceModal(true))
+        viewModel.sendEvent(BudgetEntryEvent.UpdateInvoice)
+
+        val state = viewModel.uiState.value
+        assertFalse(state.isShowInvoiceModalVisible)
+        assertTrue(state.isAttachInvoiceModalVisible)
+    }
+
+    @Test
+    fun `setBudgetEntry validates invoice file`() = runTest {
+        val validateUseCase = FakeValidateFilePathUseCase()
+        validateUseCase.validPath = "/validated/path.pdf"
+
+        val viewModel = createViewModel(validateUseCase = validateUseCase)
+        val entry = BudgetEntry(id = 1, budgetId = 1, amount = "100", invoice = "/path/invoice.pdf")
+
+        viewModel.sendEvent(BudgetEntryEvent.SetBudgetEntry(entry))
+
+        kotlinx.coroutines.delay(100)
+
+        val state = viewModel.uiState.value
+        assertTrue(state.isFileValid)
+        assertEquals("/validated/path.pdf", state.validatedFilePath)
+    }
+
+    @Test
+    fun `setBudgetEntry handles null invoice`() = runTest {
+        val viewModel = createViewModel()
+        val entry = BudgetEntry(id = 1, budgetId = 1, amount = "100", invoice = null)
+
+        viewModel.sendEvent(BudgetEntryEvent.SetBudgetEntry(entry))
+
+        kotlinx.coroutines.delay(100)
+
+        val state = viewModel.uiState.value
+        assertTrue(state.isFileValid)
+        assertNull(state.validatedFilePath)
+    }
+}

--- a/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/budgetList/BudgetListViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/budgetList/BudgetListViewModelTest.kt
@@ -1,9 +1,6 @@
 package com.meneses.budgethunter.budgetList
 
 import com.meneses.budgethunter.budgetList.application.BudgetListEvent
-import com.meneses.budgethunter.budgetList.application.IDeleteBudgetUseCase
-import com.meneses.budgethunter.budgetList.application.IDuplicateBudgetUseCase
-import com.meneses.budgethunter.budgetList.data.IBudgetRepository
 import com.meneses.budgethunter.budgetList.domain.Budget
 import com.meneses.budgethunter.fakes.repository.FakeBudgetRepository
 import com.meneses.budgethunter.fakes.usecase.FakeDeleteBudgetUseCase

--- a/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/budgetList/BudgetListViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/budgetList/BudgetListViewModelTest.kt
@@ -1,6 +1,9 @@
 package com.meneses.budgethunter.budgetList
 
 import com.meneses.budgethunter.budgetList.application.BudgetListEvent
+import com.meneses.budgethunter.budgetList.application.IDeleteBudgetUseCase
+import com.meneses.budgethunter.budgetList.application.IDuplicateBudgetUseCase
+import com.meneses.budgethunter.budgetList.data.IBudgetRepository
 import com.meneses.budgethunter.budgetList.domain.Budget
 import com.meneses.budgethunter.fakes.repository.FakeBudgetRepository
 import com.meneses.budgethunter.fakes.usecase.FakeDeleteBudgetUseCase

--- a/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/budgetList/BudgetListViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/budgetList/BudgetListViewModelTest.kt
@@ -16,7 +16,7 @@ class BudgetListViewModelTest {
 
     @Test
     fun `initial state is loading with empty budget list`() = runTest {
-        val repository = FakeBudgetRepository()
+        val repository: IBudgetRepository = FakeBudgetRepository()
         val viewModel = BudgetListViewModel(repository, FakeDuplicateBudgetUseCase(), FakeDeleteBudgetUseCase())
 
         val state = viewModel.uiState.value
@@ -25,7 +25,7 @@ class BudgetListViewModelTest {
 
     @Test
     fun `collectBudgetList updates state with budgets from repository`() = runTest {
-        val repository = FakeBudgetRepository()
+        val repository: IBudgetRepository = FakeBudgetRepository()
         val budgets = listOf(
             Budget(id = 1, name = "Budget 1", amount = 100.0),
             Budget(id = 2, name = "Budget 2", amount = 200.0)
@@ -43,7 +43,7 @@ class BudgetListViewModelTest {
 
     @Test
     fun `createBudget adds new budget and navigates to it`() = runTest {
-        val repository = FakeBudgetRepository()
+        val repository: IBudgetRepository = FakeBudgetRepository()
         val viewModel = BudgetListViewModel(repository, FakeDuplicateBudgetUseCase(), FakeDeleteBudgetUseCase())
 
         val newBudget = Budget(id = -1, name = "New Budget", amount = 500.0)
@@ -58,7 +58,7 @@ class BudgetListViewModelTest {
 
     @Test
     fun `updateBudget calls repository update`() = runTest {
-        val repository = FakeBudgetRepository()
+        val repository: IBudgetRepository = FakeBudgetRepository()
         val viewModel = BudgetListViewModel(repository, FakeDuplicateBudgetUseCase(), FakeDeleteBudgetUseCase())
 
         val budget = Budget(id = 1, name = "Updated", amount = 300.0)
@@ -72,7 +72,7 @@ class BudgetListViewModelTest {
 
     @Test
     fun `duplicateBudget calls use case`() = runTest {
-        val duplicateUseCase = FakeDuplicateBudgetUseCase()
+        val duplicateUseCase: IDuplicateBudgetUseCase = FakeDuplicateBudgetUseCase()
         val viewModel = BudgetListViewModel(FakeBudgetRepository(), duplicateUseCase, FakeDeleteBudgetUseCase())
 
         val budget = Budget(id = 1, name = "Original", amount = 100.0)
@@ -85,7 +85,7 @@ class BudgetListViewModelTest {
 
     @Test
     fun `deleteBudget calls use case with correct id`() = runTest {
-        val deleteUseCase = FakeDeleteBudgetUseCase()
+        val deleteUseCase: IDeleteBudgetUseCase = FakeDeleteBudgetUseCase()
         val viewModel = BudgetListViewModel(FakeBudgetRepository(), FakeDuplicateBudgetUseCase(), deleteUseCase)
 
         viewModel.sendEvent(BudgetListEvent.DeleteBudget(42L))
@@ -97,7 +97,7 @@ class BudgetListViewModelTest {
 
     @Test
     fun `openBudget sets navigation state`() = runTest {
-        val repository = FakeBudgetRepository()
+        val repository: IBudgetRepository = FakeBudgetRepository()
         val viewModel = BudgetListViewModel(repository, FakeDuplicateBudgetUseCase(), FakeDeleteBudgetUseCase())
 
         val budget = Budget(id = 1, name = "Test", amount = 100.0)
@@ -109,7 +109,7 @@ class BudgetListViewModelTest {
 
     @Test
     fun `clearNavigation resets navigation state`() = runTest {
-        val repository = FakeBudgetRepository()
+        val repository: IBudgetRepository = FakeBudgetRepository()
         val viewModel = BudgetListViewModel(repository, FakeDuplicateBudgetUseCase(), FakeDeleteBudgetUseCase())
 
         val budget = Budget(id = 1, name = "Test", amount = 100.0)
@@ -165,7 +165,7 @@ class BudgetListViewModelTest {
 
     @Test
     fun `updateSearchQuery filters budget list by name`() = runTest {
-        val repository = FakeBudgetRepository()
+        val repository: IBudgetRepository = FakeBudgetRepository()
         val budgets = listOf(
             Budget(id = 1, name = "Food Budget", amount = 100.0),
             Budget(id = 2, name = "Transport Budget", amount = 200.0),
@@ -187,7 +187,7 @@ class BudgetListViewModelTest {
 
     @Test
     fun `updateSearchQuery is case insensitive`() = runTest {
-        val repository = FakeBudgetRepository()
+        val repository: IBudgetRepository = FakeBudgetRepository()
         val budgets = listOf(
             Budget(id = 1, name = "FOOD BUDGET", amount = 100.0),
             Budget(id = 2, name = "food budget", amount = 200.0)
@@ -206,7 +206,7 @@ class BudgetListViewModelTest {
 
     @Test
     fun `updateSearchQuery with empty string shows all budgets`() = runTest {
-        val repository = FakeBudgetRepository()
+        val repository: IBudgetRepository = FakeBudgetRepository()
         val budgets = listOf(
             Budget(id = 1, name = "Budget 1", amount = 100.0),
             Budget(id = 2, name = "Budget 2", amount = 200.0)
@@ -227,7 +227,7 @@ class BudgetListViewModelTest {
 
     @Test
     fun `clearFilter restores full budget list`() = runTest {
-        val repository = FakeBudgetRepository()
+        val repository: IBudgetRepository = FakeBudgetRepository()
         val budgets = listOf(
             Budget(id = 1, name = "Budget 1", amount = 100.0),
             Budget(id = 2, name = "Budget 2", amount = 200.0)

--- a/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/budgetList/BudgetListViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/budgetList/BudgetListViewModelTest.kt
@@ -1,6 +1,7 @@
 package com.meneses.budgethunter.budgetList
 
 import com.meneses.budgethunter.budgetList.application.BudgetListEvent
+import com.meneses.budgethunter.budgetList.data.IBudgetRepository
 import com.meneses.budgethunter.budgetList.domain.Budget
 import com.meneses.budgethunter.fakes.repository.FakeBudgetRepository
 import com.meneses.budgethunter.fakes.usecase.FakeDeleteBudgetUseCase

--- a/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/budgetList/BudgetListViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/budgetList/BudgetListViewModelTest.kt
@@ -28,14 +28,14 @@ class BudgetListViewModelTest {
 
     @Test
     fun `collectBudgetList updates state with budgets from repository`() = runTest {
-        val repository: IBudgetRepository = FakeBudgetRepository()
+        val fakeRepository = FakeBudgetRepository()
         val budgets = listOf(
             Budget(id = 1, name = "Budget 1", amount = 100.0),
             Budget(id = 2, name = "Budget 2", amount = 200.0)
         )
-        repository.emitBudgets(budgets)
+        fakeRepository.emitBudgets(budgets)
 
-        val viewModel = BudgetListViewModel(repository, FakeDuplicateBudgetUseCase(), FakeDeleteBudgetUseCase())
+        val viewModel = BudgetListViewModel(fakeRepository, FakeDuplicateBudgetUseCase(), FakeDeleteBudgetUseCase())
 
         kotlinx.coroutines.delay(100)
 
@@ -46,56 +46,56 @@ class BudgetListViewModelTest {
 
     @Test
     fun `createBudget adds new budget and navigates to it`() = runTest {
-        val repository: IBudgetRepository = FakeBudgetRepository()
-        val viewModel = BudgetListViewModel(repository, FakeDuplicateBudgetUseCase(), FakeDeleteBudgetUseCase())
+        val fakeRepository = FakeBudgetRepository()
+        val viewModel = BudgetListViewModel(fakeRepository, FakeDuplicateBudgetUseCase(), FakeDeleteBudgetUseCase())
 
         val newBudget = Budget(id = -1, name = "New Budget", amount = 500.0)
         viewModel.sendEvent(BudgetListEvent.CreateBudget(newBudget))
 
         kotlinx.coroutines.delay(100)
 
-        assertEquals(1, repository.createdBudgets.size)
+        assertEquals(1, fakeRepository.createdBudgets.size)
         val state = viewModel.uiState.value
         assertEquals(1, state.navigateToBudget?.id)
     }
 
     @Test
     fun `updateBudget calls repository update`() = runTest {
-        val repository: IBudgetRepository = FakeBudgetRepository()
-        val viewModel = BudgetListViewModel(repository, FakeDuplicateBudgetUseCase(), FakeDeleteBudgetUseCase())
+        val fakeRepository = FakeBudgetRepository()
+        val viewModel = BudgetListViewModel(fakeRepository, FakeDuplicateBudgetUseCase(), FakeDeleteBudgetUseCase())
 
         val budget = Budget(id = 1, name = "Updated", amount = 300.0)
         viewModel.sendEvent(BudgetListEvent.UpdateBudget(budget))
 
         kotlinx.coroutines.delay(100)
 
-        assertEquals(1, repository.updatedBudgets.size)
-        assertEquals("Updated", repository.updatedBudgets[0].name)
+        assertEquals(1, fakeRepository.updatedBudgets.size)
+        assertEquals("Updated", fakeRepository.updatedBudgets[0].name)
     }
 
     @Test
     fun `duplicateBudget calls use case`() = runTest {
-        val duplicateUseCase: IDuplicateBudgetUseCase = FakeDuplicateBudgetUseCase()
-        val viewModel = BudgetListViewModel(FakeBudgetRepository(), duplicateUseCase, FakeDeleteBudgetUseCase())
+        val fakeDuplicateUseCase = FakeDuplicateBudgetUseCase()
+        val viewModel = BudgetListViewModel(FakeBudgetRepository(), fakeDuplicateUseCase, FakeDeleteBudgetUseCase())
 
         val budget = Budget(id = 1, name = "Original", amount = 100.0)
         viewModel.sendEvent(BudgetListEvent.DuplicateBudget(budget))
 
         kotlinx.coroutines.delay(100)
 
-        assertEquals(1, duplicateUseCase.duplicatedBudgets.size)
+        assertEquals(1, fakeDuplicateUseCase.duplicatedBudgets.size)
     }
 
     @Test
     fun `deleteBudget calls use case with correct id`() = runTest {
-        val deleteUseCase: IDeleteBudgetUseCase = FakeDeleteBudgetUseCase()
-        val viewModel = BudgetListViewModel(FakeBudgetRepository(), FakeDuplicateBudgetUseCase(), deleteUseCase)
+        val fakeDeleteUseCase = FakeDeleteBudgetUseCase()
+        val viewModel = BudgetListViewModel(FakeBudgetRepository(), FakeDuplicateBudgetUseCase(), fakeDeleteUseCase)
 
         viewModel.sendEvent(BudgetListEvent.DeleteBudget(42L))
 
         kotlinx.coroutines.delay(100)
 
-        assertEquals(listOf(42L), deleteUseCase.deletedBudgetIds)
+        assertEquals(listOf(42L), fakeDeleteUseCase.deletedBudgetIds)
     }
 
     @Test
@@ -168,15 +168,15 @@ class BudgetListViewModelTest {
 
     @Test
     fun `updateSearchQuery filters budget list by name`() = runTest {
-        val repository: IBudgetRepository = FakeBudgetRepository()
+        val fakeRepository = FakeBudgetRepository()
         val budgets = listOf(
             Budget(id = 1, name = "Food Budget", amount = 100.0),
             Budget(id = 2, name = "Transport Budget", amount = 200.0),
             Budget(id = 3, name = "Food and Drinks", amount = 150.0)
         )
-        repository.emitBudgets(budgets)
+        fakeRepository.emitBudgets(budgets)
 
-        val viewModel = BudgetListViewModel(repository, FakeDuplicateBudgetUseCase(), FakeDeleteBudgetUseCase())
+        val viewModel = BudgetListViewModel(fakeRepository, FakeDuplicateBudgetUseCase(), FakeDeleteBudgetUseCase())
 
         kotlinx.coroutines.delay(100)
         viewModel.sendEvent(BudgetListEvent.UpdateSearchQuery("Food"))
@@ -190,14 +190,14 @@ class BudgetListViewModelTest {
 
     @Test
     fun `updateSearchQuery is case insensitive`() = runTest {
-        val repository: IBudgetRepository = FakeBudgetRepository()
+        val fakeRepository = FakeBudgetRepository()
         val budgets = listOf(
             Budget(id = 1, name = "FOOD BUDGET", amount = 100.0),
             Budget(id = 2, name = "food budget", amount = 200.0)
         )
-        repository.emitBudgets(budgets)
+        fakeRepository.emitBudgets(budgets)
 
-        val viewModel = BudgetListViewModel(repository, FakeDuplicateBudgetUseCase(), FakeDeleteBudgetUseCase())
+        val viewModel = BudgetListViewModel(fakeRepository, FakeDuplicateBudgetUseCase(), FakeDeleteBudgetUseCase())
 
         kotlinx.coroutines.delay(100)
         viewModel.sendEvent(BudgetListEvent.UpdateSearchQuery("FoOd"))
@@ -209,14 +209,14 @@ class BudgetListViewModelTest {
 
     @Test
     fun `updateSearchQuery with empty string shows all budgets`() = runTest {
-        val repository: IBudgetRepository = FakeBudgetRepository()
+        val fakeRepository = FakeBudgetRepository()
         val budgets = listOf(
             Budget(id = 1, name = "Budget 1", amount = 100.0),
             Budget(id = 2, name = "Budget 2", amount = 200.0)
         )
-        repository.emitBudgets(budgets)
+        fakeRepository.emitBudgets(budgets)
 
-        val viewModel = BudgetListViewModel(repository, FakeDuplicateBudgetUseCase(), FakeDeleteBudgetUseCase())
+        val viewModel = BudgetListViewModel(fakeRepository, FakeDuplicateBudgetUseCase(), FakeDeleteBudgetUseCase())
 
         kotlinx.coroutines.delay(100)
         viewModel.sendEvent(BudgetListEvent.UpdateSearchQuery("Budget 1"))
@@ -230,14 +230,14 @@ class BudgetListViewModelTest {
 
     @Test
     fun `clearFilter restores full budget list`() = runTest {
-        val repository: IBudgetRepository = FakeBudgetRepository()
+        val fakeRepository = FakeBudgetRepository()
         val budgets = listOf(
             Budget(id = 1, name = "Budget 1", amount = 100.0),
             Budget(id = 2, name = "Budget 2", amount = 200.0)
         )
-        repository.emitBudgets(budgets)
+        fakeRepository.emitBudgets(budgets)
 
-        val viewModel = BudgetListViewModel(repository, FakeDuplicateBudgetUseCase(), FakeDeleteBudgetUseCase())
+        val viewModel = BudgetListViewModel(fakeRepository, FakeDuplicateBudgetUseCase(), FakeDeleteBudgetUseCase())
 
         kotlinx.coroutines.delay(100)
         viewModel.sendEvent(BudgetListEvent.ClearFilter)

--- a/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/budgetList/BudgetListViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/budgetList/BudgetListViewModelTest.kt
@@ -1,0 +1,304 @@
+package com.meneses.budgethunter.budgetList
+
+import com.meneses.budgethunter.budgetList.application.BudgetListEvent
+import com.meneses.budgethunter.budgetList.application.DeleteBudgetUseCase
+import com.meneses.budgethunter.budgetList.application.DuplicateBudgetUseCase
+import com.meneses.budgethunter.budgetList.data.BudgetRepository
+import com.meneses.budgethunter.budgetList.domain.Budget
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class BudgetListViewModelTest {
+
+    private class FakeBudgetRepository : BudgetRepository {
+        private val _budgets = MutableStateFlow<List<Budget>>(emptyList())
+        override val budgets: StateFlow<List<Budget>> = _budgets
+
+        val createdBudgets = mutableListOf<Budget>()
+        val updatedBudgets = mutableListOf<Budget>()
+        private val budgetCache = mutableListOf<Budget>()
+
+        fun emitBudgets(budgetList: List<Budget>) {
+            budgetCache.clear()
+            budgetCache.addAll(budgetList)
+            _budgets.value = budgetList
+        }
+
+        override suspend fun create(budget: Budget): Budget {
+            val newBudget = budget.copy(id = (budgetCache.maxOfOrNull { it.id } ?: 0) + 1)
+            createdBudgets.add(newBudget)
+            budgetCache.add(newBudget)
+            _budgets.value = budgetCache.toList()
+            return newBudget
+        }
+
+        override suspend fun update(budget: Budget) {
+            updatedBudgets.add(budget)
+            val index = budgetCache.indexOfFirst { it.id == budget.id }
+            if (index >= 0) {
+                budgetCache[index] = budget
+                _budgets.value = budgetCache.toList()
+            }
+        }
+
+        override suspend fun getById(id: Int): Budget? {
+            return budgetCache.find { it.id == id }
+        }
+
+        override suspend fun getAllCached(): List<Budget> = budgetCache.toList()
+
+        override suspend fun getAllFilteredBy(filter: Any?): List<Budget> = budgetCache.toList()
+    }
+
+    private class FakeDuplicateBudgetUseCase : DuplicateBudgetUseCase(null!!, null!!, null!!) {
+        val duplicatedBudgets = mutableListOf<Budget>()
+
+        override suspend fun execute(budget: Budget) {
+            duplicatedBudgets.add(budget)
+        }
+    }
+
+    private class FakeDeleteBudgetUseCase : DeleteBudgetUseCase(null!!, null!!, null!!) {
+        val deletedBudgetIds = mutableListOf<Long>()
+
+        override suspend fun execute(budgetId: Long) {
+            deletedBudgetIds.add(budgetId)
+        }
+    }
+
+    @Test
+    fun `initial state is loading with empty budget list`() = runTest {
+        val repository = FakeBudgetRepository()
+        val viewModel = BudgetListViewModel(repository, FakeDuplicateBudgetUseCase(), FakeDeleteBudgetUseCase())
+
+        val state = viewModel.uiState.value
+        assertTrue(state.budgetList.isEmpty())
+    }
+
+    @Test
+    fun `collectBudgetList updates state with budgets from repository`() = runTest {
+        val repository = FakeBudgetRepository()
+        val budgets = listOf(
+            Budget(id = 1, name = "Budget 1", amount = 100.0),
+            Budget(id = 2, name = "Budget 2", amount = 200.0)
+        )
+        repository.emitBudgets(budgets)
+
+        val viewModel = BudgetListViewModel(repository, FakeDuplicateBudgetUseCase(), FakeDeleteBudgetUseCase())
+
+        kotlinx.coroutines.delay(100)
+
+        val state = viewModel.uiState.value
+        assertEquals(2, state.budgetList.size)
+        assertFalse(state.isLoading)
+    }
+
+    @Test
+    fun `createBudget adds new budget and navigates to it`() = runTest {
+        val repository = FakeBudgetRepository()
+        val viewModel = BudgetListViewModel(repository, FakeDuplicateBudgetUseCase(), FakeDeleteBudgetUseCase())
+
+        val newBudget = Budget(id = -1, name = "New Budget", amount = 500.0)
+        viewModel.sendEvent(BudgetListEvent.CreateBudget(newBudget))
+
+        kotlinx.coroutines.delay(100)
+
+        assertEquals(1, repository.createdBudgets.size)
+        val state = viewModel.uiState.value
+        assertEquals(1, state.navigateToBudget?.id)
+    }
+
+    @Test
+    fun `updateBudget calls repository update`() = runTest {
+        val repository = FakeBudgetRepository()
+        val viewModel = BudgetListViewModel(repository, FakeDuplicateBudgetUseCase(), FakeDeleteBudgetUseCase())
+
+        val budget = Budget(id = 1, name = "Updated", amount = 300.0)
+        viewModel.sendEvent(BudgetListEvent.UpdateBudget(budget))
+
+        kotlinx.coroutines.delay(100)
+
+        assertEquals(1, repository.updatedBudgets.size)
+        assertEquals("Updated", repository.updatedBudgets[0].name)
+    }
+
+    @Test
+    fun `duplicateBudget calls use case`() = runTest {
+        val duplicateUseCase = FakeDuplicateBudgetUseCase()
+        val viewModel = BudgetListViewModel(FakeBudgetRepository(), duplicateUseCase, FakeDeleteBudgetUseCase())
+
+        val budget = Budget(id = 1, name = "Original", amount = 100.0)
+        viewModel.sendEvent(BudgetListEvent.DuplicateBudget(budget))
+
+        kotlinx.coroutines.delay(100)
+
+        assertEquals(1, duplicateUseCase.duplicatedBudgets.size)
+    }
+
+    @Test
+    fun `deleteBudget calls use case with correct id`() = runTest {
+        val deleteUseCase = FakeDeleteBudgetUseCase()
+        val viewModel = BudgetListViewModel(FakeBudgetRepository(), FakeDuplicateBudgetUseCase(), deleteUseCase)
+
+        viewModel.sendEvent(BudgetListEvent.DeleteBudget(42L))
+
+        kotlinx.coroutines.delay(100)
+
+        assertEquals(listOf(42L), deleteUseCase.deletedBudgetIds)
+    }
+
+    @Test
+    fun `openBudget sets navigation state`() = runTest {
+        val repository = FakeBudgetRepository()
+        val viewModel = BudgetListViewModel(repository, FakeDuplicateBudgetUseCase(), FakeDeleteBudgetUseCase())
+
+        val budget = Budget(id = 1, name = "Test", amount = 100.0)
+        viewModel.sendEvent(BudgetListEvent.OpenBudget(budget))
+
+        val state = viewModel.uiState.value
+        assertEquals(budget, state.navigateToBudget)
+    }
+
+    @Test
+    fun `clearNavigation resets navigation state`() = runTest {
+        val repository = FakeBudgetRepository()
+        val viewModel = BudgetListViewModel(repository, FakeDuplicateBudgetUseCase(), FakeDeleteBudgetUseCase())
+
+        val budget = Budget(id = 1, name = "Test", amount = 100.0)
+        viewModel.sendEvent(BudgetListEvent.OpenBudget(budget))
+        viewModel.sendEvent(BudgetListEvent.ClearNavigation)
+
+        val state = viewModel.uiState.value
+        assertNull(state.navigateToBudget)
+    }
+
+    @Test
+    fun `toggleAddModal sets visibility state`() = runTest {
+        val viewModel = BudgetListViewModel(FakeBudgetRepository(), FakeDuplicateBudgetUseCase(), FakeDeleteBudgetUseCase())
+
+        viewModel.sendEvent(BudgetListEvent.ToggleAddModal(true))
+        assertTrue(viewModel.uiState.value.addModalVisibility)
+
+        viewModel.sendEvent(BudgetListEvent.ToggleAddModal(false))
+        assertFalse(viewModel.uiState.value.addModalVisibility)
+    }
+
+    @Test
+    fun `toggleUpdateModal sets budget to update`() = runTest {
+        val viewModel = BudgetListViewModel(FakeBudgetRepository(), FakeDuplicateBudgetUseCase(), FakeDeleteBudgetUseCase())
+
+        val budget = Budget(id = 1, name = "Test", amount = 100.0)
+        viewModel.sendEvent(BudgetListEvent.ToggleUpdateModal(budget))
+
+        assertEquals(budget, viewModel.uiState.value.budgetToUpdate)
+    }
+
+    @Test
+    fun `toggleSearchMode activates search mode`() = runTest {
+        val viewModel = BudgetListViewModel(FakeBudgetRepository(), FakeDuplicateBudgetUseCase(), FakeDeleteBudgetUseCase())
+
+        viewModel.sendEvent(BudgetListEvent.ToggleSearchMode(true))
+
+        assertTrue(viewModel.uiState.value.isSearchMode)
+    }
+
+    @Test
+    fun `toggleSearchMode deactivates search mode and clears query`() = runTest {
+        val viewModel = BudgetListViewModel(FakeBudgetRepository(), FakeDuplicateBudgetUseCase(), FakeDeleteBudgetUseCase())
+
+        viewModel.sendEvent(BudgetListEvent.UpdateSearchQuery("test"))
+        viewModel.sendEvent(BudgetListEvent.ToggleSearchMode(true))
+        viewModel.sendEvent(BudgetListEvent.ToggleSearchMode(false))
+
+        val state = viewModel.uiState.value
+        assertFalse(state.isSearchMode)
+        assertEquals("", state.searchQuery)
+    }
+
+    @Test
+    fun `updateSearchQuery filters budget list by name`() = runTest {
+        val repository = FakeBudgetRepository()
+        val budgets = listOf(
+            Budget(id = 1, name = "Food Budget", amount = 100.0),
+            Budget(id = 2, name = "Transport Budget", amount = 200.0),
+            Budget(id = 3, name = "Food and Drinks", amount = 150.0)
+        )
+        repository.emitBudgets(budgets)
+
+        val viewModel = BudgetListViewModel(repository, FakeDuplicateBudgetUseCase(), FakeDeleteBudgetUseCase())
+
+        kotlinx.coroutines.delay(100)
+        viewModel.sendEvent(BudgetListEvent.UpdateSearchQuery("Food"))
+        kotlinx.coroutines.delay(100)
+
+        val state = viewModel.uiState.value
+        assertEquals("Food", state.searchQuery)
+        assertEquals(2, state.budgetList.size)
+        assertTrue(state.budgetList.all { it.name.contains("Food", ignoreCase = true) })
+    }
+
+    @Test
+    fun `updateSearchQuery is case insensitive`() = runTest {
+        val repository = FakeBudgetRepository()
+        val budgets = listOf(
+            Budget(id = 1, name = "FOOD BUDGET", amount = 100.0),
+            Budget(id = 2, name = "food budget", amount = 200.0)
+        )
+        repository.emitBudgets(budgets)
+
+        val viewModel = BudgetListViewModel(repository, FakeDuplicateBudgetUseCase(), FakeDeleteBudgetUseCase())
+
+        kotlinx.coroutines.delay(100)
+        viewModel.sendEvent(BudgetListEvent.UpdateSearchQuery("FoOd"))
+        kotlinx.coroutines.delay(100)
+
+        val state = viewModel.uiState.value
+        assertEquals(2, state.budgetList.size)
+    }
+
+    @Test
+    fun `updateSearchQuery with empty string shows all budgets`() = runTest {
+        val repository = FakeBudgetRepository()
+        val budgets = listOf(
+            Budget(id = 1, name = "Budget 1", amount = 100.0),
+            Budget(id = 2, name = "Budget 2", amount = 200.0)
+        )
+        repository.emitBudgets(budgets)
+
+        val viewModel = BudgetListViewModel(repository, FakeDuplicateBudgetUseCase(), FakeDeleteBudgetUseCase())
+
+        kotlinx.coroutines.delay(100)
+        viewModel.sendEvent(BudgetListEvent.UpdateSearchQuery("Budget 1"))
+        kotlinx.coroutines.delay(100)
+        viewModel.sendEvent(BudgetListEvent.UpdateSearchQuery(""))
+        kotlinx.coroutines.delay(100)
+
+        val state = viewModel.uiState.value
+        assertEquals(2, state.budgetList.size)
+    }
+
+    @Test
+    fun `clearFilter restores full budget list`() = runTest {
+        val repository = FakeBudgetRepository()
+        val budgets = listOf(
+            Budget(id = 1, name = "Budget 1", amount = 100.0),
+            Budget(id = 2, name = "Budget 2", amount = 200.0)
+        )
+        repository.emitBudgets(budgets)
+
+        val viewModel = BudgetListViewModel(repository, FakeDuplicateBudgetUseCase(), FakeDeleteBudgetUseCase())
+
+        kotlinx.coroutines.delay(100)
+        viewModel.sendEvent(BudgetListEvent.ClearFilter)
+        kotlinx.coroutines.delay(100)
+
+        val state = viewModel.uiState.value
+        assertNull(state.filter)
+    }
+}

--- a/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/budgetMetrics/BudgetMetricsViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/budgetMetrics/BudgetMetricsViewModelTest.kt
@@ -15,7 +15,7 @@ class BudgetMetricsViewModelTest {
             "Transport" to 50.0,
             "Entertainment" to 25.0
         )
-        val useCase = FakeGetTotalsPerCategoryUseCase(totals)
+        val useCase: IGetTotalsPerCategoryUseCase = FakeGetTotalsPerCategoryUseCase(totals)
         val viewModel = BudgetMetricsViewModel(useCase)
 
         // Wait for initialization
@@ -32,7 +32,7 @@ class BudgetMetricsViewModelTest {
             "Transport" to 50.0,
             "Entertainment" to 50.0
         )
-        val useCase = FakeGetTotalsPerCategoryUseCase(totals)
+        val useCase: IGetTotalsPerCategoryUseCase = FakeGetTotalsPerCategoryUseCase(totals)
         val viewModel = BudgetMetricsViewModel(useCase)
 
         kotlinx.coroutines.delay(100)
@@ -50,7 +50,7 @@ class BudgetMetricsViewModelTest {
             "Transport" to 50.0,
             "Entertainment" to 25.0
         )
-        val useCase = FakeGetTotalsPerCategoryUseCase(totals)
+        val useCase: IGetTotalsPerCategoryUseCase = FakeGetTotalsPerCategoryUseCase(totals)
         val viewModel = BudgetMetricsViewModel(useCase)
 
         kotlinx.coroutines.delay(100)
@@ -61,7 +61,7 @@ class BudgetMetricsViewModelTest {
 
     @Test
     fun `handles empty metrics data`() = runTest {
-        val useCase = FakeGetTotalsPerCategoryUseCase(emptyMap())
+        val useCase: IGetTotalsPerCategoryUseCase = FakeGetTotalsPerCategoryUseCase(emptyMap())
         val viewModel = BudgetMetricsViewModel(useCase)
 
         kotlinx.coroutines.delay(100)
@@ -75,7 +75,7 @@ class BudgetMetricsViewModelTest {
     @Test
     fun `handles single category`() = runTest {
         val totals = mapOf("Food" to 150.0)
-        val useCase = FakeGetTotalsPerCategoryUseCase(totals)
+        val useCase: IGetTotalsPerCategoryUseCase = FakeGetTotalsPerCategoryUseCase(totals)
         val viewModel = BudgetMetricsViewModel(useCase)
 
         kotlinx.coroutines.delay(100)
@@ -89,7 +89,7 @@ class BudgetMetricsViewModelTest {
     @Test
     fun `handles large number of categories`() = runTest {
         val totals = (1..10).associate { "Category$it" to it * 10.0 }
-        val useCase = FakeGetTotalsPerCategoryUseCase(totals)
+        val useCase: IGetTotalsPerCategoryUseCase = FakeGetTotalsPerCategoryUseCase(totals)
         val viewModel = BudgetMetricsViewModel(useCase)
 
         kotlinx.coroutines.delay(100)
@@ -107,7 +107,7 @@ class BudgetMetricsViewModelTest {
             "Transport" to 100.0,
             "Entertainment" to 100.0
         )
-        val useCase = FakeGetTotalsPerCategoryUseCase(totals)
+        val useCase: IGetTotalsPerCategoryUseCase = FakeGetTotalsPerCategoryUseCase(totals)
         val viewModel = BudgetMetricsViewModel(useCase)
 
         kotlinx.coroutines.delay(100)
@@ -125,7 +125,7 @@ class BudgetMetricsViewModelTest {
             "Food" to 33.33,
             "Transport" to 66.67
         )
-        val useCase = FakeGetTotalsPerCategoryUseCase(totals)
+        val useCase: IGetTotalsPerCategoryUseCase = FakeGetTotalsPerCategoryUseCase(totals)
         val viewModel = BudgetMetricsViewModel(useCase)
 
         kotlinx.coroutines.delay(100)
@@ -138,7 +138,7 @@ class BudgetMetricsViewModelTest {
     @Test
     fun `uiState exposes state as flow`() = runTest {
         val totals = mapOf("Food" to 100.0)
-        val useCase = FakeGetTotalsPerCategoryUseCase(totals)
+        val useCase: IGetTotalsPerCategoryUseCase = FakeGetTotalsPerCategoryUseCase(totals)
         val viewModel = BudgetMetricsViewModel(useCase)
 
         kotlinx.coroutines.delay(100)

--- a/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/budgetMetrics/BudgetMetricsViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/budgetMetrics/BudgetMetricsViewModelTest.kt
@@ -1,0 +1,164 @@
+package com.meneses.budgethunter.budgetMetrics
+
+import com.meneses.budgethunter.budgetMetrics.application.GetTotalsPerCategoryUseCase
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class BudgetMetricsViewModelTest {
+
+    private class FakeGetTotalsPerCategoryUseCase(
+        private val totalsMap: Map<String, Double> = emptyMap()
+    ) : GetTotalsPerCategoryUseCase(
+        budgetDetailRepository = null!!,
+        ioDispatcher = Dispatchers.Default
+    ) {
+        override suspend fun execute(): Map<String, Double> {
+            return totalsMap
+        }
+    }
+
+    @Test
+    fun `initial state loads metrics on initialization`() = runTest {
+        val totals = mapOf(
+            "Food" to 100.0,
+            "Transport" to 50.0,
+            "Entertainment" to 25.0
+        )
+        val useCase = FakeGetTotalsPerCategoryUseCase(totals)
+        val viewModel = BudgetMetricsViewModel(useCase)
+
+        // Wait for initialization
+        kotlinx.coroutines.delay(100)
+
+        val state = viewModel.uiState.value
+        assertEquals(totals, state.metricsData)
+    }
+
+    @Test
+    fun `calculates correct percentages from totals`() = runTest {
+        val totals = mapOf(
+            "Food" to 100.0,
+            "Transport" to 50.0,
+            "Entertainment" to 50.0
+        )
+        val useCase = FakeGetTotalsPerCategoryUseCase(totals)
+        val viewModel = BudgetMetricsViewModel(useCase)
+
+        kotlinx.coroutines.delay(100)
+
+        val state = viewModel.uiState.value
+        val expectedPercentages = listOf(50.0, 25.0, 25.0) // 100/200, 50/200, 50/200
+
+        assertEquals(expectedPercentages, state.percentages)
+    }
+
+    @Test
+    fun `assigns correct number of colors based on categories`() = runTest {
+        val totals = mapOf(
+            "Food" to 100.0,
+            "Transport" to 50.0,
+            "Entertainment" to 25.0
+        )
+        val useCase = FakeGetTotalsPerCategoryUseCase(totals)
+        val viewModel = BudgetMetricsViewModel(useCase)
+
+        kotlinx.coroutines.delay(100)
+
+        val state = viewModel.uiState.value
+        assertEquals(3, state.chartColors.size)
+    }
+
+    @Test
+    fun `handles empty metrics data`() = runTest {
+        val useCase = FakeGetTotalsPerCategoryUseCase(emptyMap())
+        val viewModel = BudgetMetricsViewModel(useCase)
+
+        kotlinx.coroutines.delay(100)
+
+        val state = viewModel.uiState.value
+        assertEquals(emptyMap(), state.metricsData)
+        assertTrue(state.percentages.isEmpty())
+        assertTrue(state.chartColors.isEmpty())
+    }
+
+    @Test
+    fun `handles single category`() = runTest {
+        val totals = mapOf("Food" to 150.0)
+        val useCase = FakeGetTotalsPerCategoryUseCase(totals)
+        val viewModel = BudgetMetricsViewModel(useCase)
+
+        kotlinx.coroutines.delay(100)
+
+        val state = viewModel.uiState.value
+        assertEquals(mapOf("Food" to 150.0), state.metricsData)
+        assertEquals(listOf(100.0), state.percentages)
+        assertEquals(1, state.chartColors.size)
+    }
+
+    @Test
+    fun `handles large number of categories`() = runTest {
+        val totals = (1..10).associate { "Category$it" to it * 10.0 }
+        val useCase = FakeGetTotalsPerCategoryUseCase(totals)
+        val viewModel = BudgetMetricsViewModel(useCase)
+
+        kotlinx.coroutines.delay(100)
+
+        val state = viewModel.uiState.value
+        assertEquals(10, state.metricsData.size)
+        assertEquals(10, state.percentages.size)
+        assertEquals(10, state.chartColors.size)
+    }
+
+    @Test
+    fun `percentages sum to approximately 100`() = runTest {
+        val totals = mapOf(
+            "Food" to 100.0,
+            "Transport" to 100.0,
+            "Entertainment" to 100.0
+        )
+        val useCase = FakeGetTotalsPerCategoryUseCase(totals)
+        val viewModel = BudgetMetricsViewModel(useCase)
+
+        kotlinx.coroutines.delay(100)
+
+        val state = viewModel.uiState.value
+        val sum = state.percentages.sum()
+
+        // Should sum to approximately 100 (allowing for floating point arithmetic)
+        assertTrue(sum >= 99.9 && sum <= 100.1)
+    }
+
+    @Test
+    fun `handles decimal values correctly`() = runTest {
+        val totals = mapOf(
+            "Food" to 33.33,
+            "Transport" to 66.67
+        )
+        val useCase = FakeGetTotalsPerCategoryUseCase(totals)
+        val viewModel = BudgetMetricsViewModel(useCase)
+
+        kotlinx.coroutines.delay(100)
+
+        val state = viewModel.uiState.value
+        assertEquals(2, state.percentages.size)
+        assertTrue(state.percentages.all { it > 0 })
+    }
+
+    @Test
+    fun `uiState exposes state as flow`() = runTest {
+        val totals = mapOf("Food" to 100.0)
+        val useCase = FakeGetTotalsPerCategoryUseCase(totals)
+        val viewModel = BudgetMetricsViewModel(useCase)
+
+        kotlinx.coroutines.delay(100)
+
+        val state1 = viewModel.uiState.value
+        val state2 = viewModel.uiState.value
+
+        // Both should reference the same state
+        assertEquals(state1.metricsData, state2.metricsData)
+    }
+}

--- a/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/budgetMetrics/BudgetMetricsViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/budgetMetrics/BudgetMetricsViewModelTest.kt
@@ -1,5 +1,6 @@
 package com.meneses.budgethunter.budgetMetrics
 
+import com.meneses.budgethunter.budgetMetrics.application.IGetTotalsPerCategoryUseCase
 import com.meneses.budgethunter.fakes.usecase.FakeGetTotalsPerCategoryUseCase
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test

--- a/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/budgetMetrics/BudgetMetricsViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/budgetMetrics/BudgetMetricsViewModelTest.kt
@@ -1,5 +1,6 @@
 package com.meneses.budgethunter.budgetMetrics
 
+import com.meneses.budgethunter.budgetEntry.domain.BudgetEntry
 import com.meneses.budgethunter.budgetMetrics.application.IGetTotalsPerCategoryUseCase
 import com.meneses.budgethunter.fakes.usecase.FakeGetTotalsPerCategoryUseCase
 import kotlinx.coroutines.test.runTest
@@ -12,9 +13,9 @@ class BudgetMetricsViewModelTest {
     @Test
     fun `initial state loads metrics on initialization`() = runTest {
         val totals = mapOf(
-            "Food" to 100.0,
-            "Transport" to 50.0,
-            "Entertainment" to 25.0
+            BudgetEntry.Category.FOOD to 100.0,
+            BudgetEntry.Category.TRANSPORTATION to 50.0,
+            BudgetEntry.Category.ENTERTAINMENT to 25.0
         )
         val useCase: IGetTotalsPerCategoryUseCase = FakeGetTotalsPerCategoryUseCase(totals)
         val viewModel = BudgetMetricsViewModel(useCase)
@@ -23,15 +24,15 @@ class BudgetMetricsViewModelTest {
         kotlinx.coroutines.delay(100)
 
         val state = viewModel.uiState.value
-        assertEquals<Map<String, Double>>(totals, state.metricsData)
+        assertEquals<Map<BudgetEntry.Category, Double>>(totals, state.metricsData)
     }
 
     @Test
     fun `calculates correct percentages from totals`() = runTest {
         val totals = mapOf(
-            "Food" to 100.0,
-            "Transport" to 50.0,
-            "Entertainment" to 50.0
+            BudgetEntry.Category.FOOD to 100.0,
+            BudgetEntry.Category.TRANSPORTATION to 50.0,
+            BudgetEntry.Category.ENTERTAINMENT to 50.0
         )
         val useCase: IGetTotalsPerCategoryUseCase = FakeGetTotalsPerCategoryUseCase(totals)
         val viewModel = BudgetMetricsViewModel(useCase)
@@ -47,9 +48,9 @@ class BudgetMetricsViewModelTest {
     @Test
     fun `assigns correct number of colors based on categories`() = runTest {
         val totals = mapOf(
-            "Food" to 100.0,
-            "Transport" to 50.0,
-            "Entertainment" to 25.0
+            BudgetEntry.Category.FOOD to 100.0,
+            BudgetEntry.Category.TRANSPORTATION to 50.0,
+            BudgetEntry.Category.ENTERTAINMENT to 25.0
         )
         val useCase: IGetTotalsPerCategoryUseCase = FakeGetTotalsPerCategoryUseCase(totals)
         val viewModel = BudgetMetricsViewModel(useCase)
@@ -75,21 +76,33 @@ class BudgetMetricsViewModelTest {
 
     @Test
     fun `handles single category`() = runTest {
-        val totals = mapOf("Food" to 150.0)
+        val totals = mapOf(BudgetEntry.Category.FOOD to 150.0)
         val useCase: IGetTotalsPerCategoryUseCase = FakeGetTotalsPerCategoryUseCase(totals)
         val viewModel = BudgetMetricsViewModel(useCase)
 
         kotlinx.coroutines.delay(100)
 
         val state = viewModel.uiState.value
-        assertEquals<Map<String, Double>>(mapOf("Food" to 150.0), state.metricsData)
+        assertEquals<Map<BudgetEntry.Category, Double>>(mapOf(BudgetEntry.Category.FOOD to 150.0), state.metricsData)
         assertEquals(listOf(100.0), state.percentages)
         assertEquals(1, state.chartColors.size)
     }
 
     @Test
     fun `handles large number of categories`() = runTest {
-        val totals = (1..10).associate { "Category$it" to it * 10.0 }
+        val categories = listOf(
+            BudgetEntry.Category.FOOD,
+            BudgetEntry.Category.GROCERIES,
+            BudgetEntry.Category.SELF_CARE,
+            BudgetEntry.Category.TRANSPORTATION,
+            BudgetEntry.Category.HOUSEHOLD_ITEMS,
+            BudgetEntry.Category.HEALTH,
+            BudgetEntry.Category.BILLS,
+            BudgetEntry.Category.ENTERTAINMENT,
+            BudgetEntry.Category.EDUCATION,
+            BudgetEntry.Category.GIFTS
+        )
+        val totals = categories.associateWith { it.ordinal * 10.0 + 10.0 }
         val useCase: IGetTotalsPerCategoryUseCase = FakeGetTotalsPerCategoryUseCase(totals)
         val viewModel = BudgetMetricsViewModel(useCase)
 
@@ -104,9 +117,9 @@ class BudgetMetricsViewModelTest {
     @Test
     fun `percentages sum to approximately 100`() = runTest {
         val totals = mapOf(
-            "Food" to 100.0,
-            "Transport" to 100.0,
-            "Entertainment" to 100.0
+            BudgetEntry.Category.FOOD to 100.0,
+            BudgetEntry.Category.TRANSPORTATION to 100.0,
+            BudgetEntry.Category.ENTERTAINMENT to 100.0
         )
         val useCase: IGetTotalsPerCategoryUseCase = FakeGetTotalsPerCategoryUseCase(totals)
         val viewModel = BudgetMetricsViewModel(useCase)
@@ -123,8 +136,8 @@ class BudgetMetricsViewModelTest {
     @Test
     fun `handles decimal values correctly`() = runTest {
         val totals = mapOf(
-            "Food" to 33.33,
-            "Transport" to 66.67
+            BudgetEntry.Category.FOOD to 33.33,
+            BudgetEntry.Category.TRANSPORTATION to 66.67
         )
         val useCase: IGetTotalsPerCategoryUseCase = FakeGetTotalsPerCategoryUseCase(totals)
         val viewModel = BudgetMetricsViewModel(useCase)
@@ -138,7 +151,7 @@ class BudgetMetricsViewModelTest {
 
     @Test
     fun `uiState exposes state as flow`() = runTest {
-        val totals = mapOf("Food" to 100.0)
+        val totals = mapOf(BudgetEntry.Category.FOOD to 100.0)
         val useCase: IGetTotalsPerCategoryUseCase = FakeGetTotalsPerCategoryUseCase(totals)
         val viewModel = BudgetMetricsViewModel(useCase)
 

--- a/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/budgetMetrics/BudgetMetricsViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/budgetMetrics/BudgetMetricsViewModelTest.kt
@@ -1,24 +1,12 @@
 package com.meneses.budgethunter.budgetMetrics
 
-import com.meneses.budgethunter.budgetMetrics.application.GetTotalsPerCategoryUseCase
-import kotlinx.coroutines.Dispatchers
+import com.meneses.budgethunter.fakes.usecase.FakeGetTotalsPerCategoryUseCase
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 class BudgetMetricsViewModelTest {
-
-    private class FakeGetTotalsPerCategoryUseCase(
-        private val totalsMap: Map<String, Double> = emptyMap()
-    ) : GetTotalsPerCategoryUseCase(
-        budgetDetailRepository = null!!,
-        ioDispatcher = Dispatchers.Default
-    ) {
-        override suspend fun execute(): Map<String, Double> {
-            return totalsMap
-        }
-    }
 
     @Test
     fun `initial state loads metrics on initialization`() = runTest {

--- a/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/budgetMetrics/BudgetMetricsViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/budgetMetrics/BudgetMetricsViewModelTest.kt
@@ -23,7 +23,7 @@ class BudgetMetricsViewModelTest {
         kotlinx.coroutines.delay(100)
 
         val state = viewModel.uiState.value
-        assertEquals(totals, state.metricsData)
+        assertEquals<Map<String, Double>>(totals, state.metricsData)
     }
 
     @Test
@@ -82,7 +82,7 @@ class BudgetMetricsViewModelTest {
         kotlinx.coroutines.delay(100)
 
         val state = viewModel.uiState.value
-        assertEquals(mapOf("Food" to 150.0), state.metricsData)
+        assertEquals<Map<String, Double>>(mapOf("Food" to 150.0), state.metricsData)
         assertEquals(listOf(100.0), state.percentages)
         assertEquals(1, state.chartColors.size)
     }

--- a/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/budgetMetrics/BudgetMetricsViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/budgetMetrics/BudgetMetricsViewModelTest.kt
@@ -15,7 +15,7 @@ class BudgetMetricsViewModelTest {
         val totals = mapOf(
             BudgetEntry.Category.FOOD to 100.0,
             BudgetEntry.Category.TRANSPORTATION to 50.0,
-            BudgetEntry.Category.ENTERTAINMENT to 25.0
+            BudgetEntry.Category.LEISURE to 25.0
         )
         val useCase: IGetTotalsPerCategoryUseCase = FakeGetTotalsPerCategoryUseCase(totals)
         val viewModel = BudgetMetricsViewModel(useCase)
@@ -32,7 +32,7 @@ class BudgetMetricsViewModelTest {
         val totals = mapOf(
             BudgetEntry.Category.FOOD to 100.0,
             BudgetEntry.Category.TRANSPORTATION to 50.0,
-            BudgetEntry.Category.ENTERTAINMENT to 50.0
+            BudgetEntry.Category.LEISURE to 50.0
         )
         val useCase: IGetTotalsPerCategoryUseCase = FakeGetTotalsPerCategoryUseCase(totals)
         val viewModel = BudgetMetricsViewModel(useCase)
@@ -50,7 +50,7 @@ class BudgetMetricsViewModelTest {
         val totals = mapOf(
             BudgetEntry.Category.FOOD to 100.0,
             BudgetEntry.Category.TRANSPORTATION to 50.0,
-            BudgetEntry.Category.ENTERTAINMENT to 25.0
+            BudgetEntry.Category.LEISURE to 25.0
         )
         val useCase: IGetTotalsPerCategoryUseCase = FakeGetTotalsPerCategoryUseCase(totals)
         val viewModel = BudgetMetricsViewModel(useCase)
@@ -96,11 +96,11 @@ class BudgetMetricsViewModelTest {
             BudgetEntry.Category.SELF_CARE,
             BudgetEntry.Category.TRANSPORTATION,
             BudgetEntry.Category.HOUSEHOLD_ITEMS,
-            BudgetEntry.Category.HEALTH,
-            BudgetEntry.Category.BILLS,
-            BudgetEntry.Category.ENTERTAINMENT,
+            BudgetEntry.Category.SERVICES,
             BudgetEntry.Category.EDUCATION,
-            BudgetEntry.Category.GIFTS
+            BudgetEntry.Category.HEALTH,
+            BudgetEntry.Category.LEISURE,
+            BudgetEntry.Category.TAXES
         )
         val totals = categories.associateWith { it.ordinal * 10.0 + 10.0 }
         val useCase: IGetTotalsPerCategoryUseCase = FakeGetTotalsPerCategoryUseCase(totals)
@@ -119,7 +119,7 @@ class BudgetMetricsViewModelTest {
         val totals = mapOf(
             BudgetEntry.Category.FOOD to 100.0,
             BudgetEntry.Category.TRANSPORTATION to 100.0,
-            BudgetEntry.Category.ENTERTAINMENT to 100.0
+            BudgetEntry.Category.LEISURE to 100.0
         )
         val useCase: IGetTotalsPerCategoryUseCase = FakeGetTotalsPerCategoryUseCase(totals)
         val viewModel = BudgetMetricsViewModel(useCase)

--- a/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/fakes/manager/FakeAppUpdateManager.kt
+++ b/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/fakes/manager/FakeAppUpdateManager.kt
@@ -1,11 +1,11 @@
 package com.meneses.budgethunter.fakes.manager
 
-import com.meneses.budgethunter.commons.platform.AppUpdateManager
+import com.meneses.budgethunter.commons.platform.IAppUpdateManager
 import com.meneses.budgethunter.commons.platform.AppUpdateResult
 
 class FakeAppUpdateManager(
     private val updateResult: AppUpdateResult
-) : AppUpdateManager {
+) : IAppUpdateManager {
     var checkForUpdatesCalled = false
     var startUpdateCalled = false
 

--- a/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/fakes/manager/FakeAppUpdateManager.kt
+++ b/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/fakes/manager/FakeAppUpdateManager.kt
@@ -1,0 +1,24 @@
+package com.meneses.budgethunter.fakes.manager
+
+import com.meneses.budgethunter.commons.platform.AppUpdateManager
+import com.meneses.budgethunter.commons.platform.AppUpdateResult
+
+class FakeAppUpdateManager(
+    private val updateResult: AppUpdateResult
+) : AppUpdateManager {
+    var checkForUpdatesCalled = false
+    var startUpdateCalled = false
+
+    override fun checkForUpdates(callback: (AppUpdateResult) -> Unit) {
+        checkForUpdatesCalled = true
+        callback(updateResult)
+    }
+}
+
+class FakeAppUpdateResult(
+    private val onStart: () -> Unit = {}
+) : AppUpdateResult.UpdateAvailable {
+    override fun startUpdate() {
+        onStart()
+    }
+}

--- a/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/fakes/manager/FakeAppUpdateManager.kt
+++ b/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/fakes/manager/FakeAppUpdateManager.kt
@@ -15,10 +15,8 @@ class FakeAppUpdateManager(
     }
 }
 
-class FakeAppUpdateResult(
-    private val onStart: () -> Unit = {}
-) : AppUpdateResult.UpdateAvailable {
-    override fun startUpdate() {
-        onStart()
-    }
+fun FakeAppUpdateResult(
+    onStart: () -> Unit = {}
+): AppUpdateResult.UpdateAvailable {
+    return AppUpdateResult.UpdateAvailable(startUpdate = onStart)
 }

--- a/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/fakes/manager/FakeCameraManager.kt
+++ b/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/fakes/manager/FakeCameraManager.kt
@@ -1,15 +1,24 @@
 package com.meneses.budgethunter.fakes.manager
 
+import com.meneses.budgethunter.commons.data.FileData
 import com.meneses.budgethunter.commons.platform.CameraManager
 
 class FakeCameraManager : CameraManager {
-    var callback: ((ByteArray?) -> Unit)? = null
+    var callback: ((FileData?) -> Unit)? = null
 
-    override fun takePhoto(onResult: (ByteArray?) -> Unit) {
+    override fun takePhoto(onResult: (FileData?) -> Unit) {
         callback = onResult
     }
 
     fun simulatePhotoTaken(data: ByteArray?) {
-        callback?.invoke(data)
+        val fileData = data?.let {
+            FileData(
+                data = it,
+                filename = "photo.jpg",
+                mimeType = "image/jpeg",
+                directory = "/tmp"
+            )
+        }
+        callback?.invoke(fileData)
     }
 }

--- a/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/fakes/manager/FakeCameraManager.kt
+++ b/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/fakes/manager/FakeCameraManager.kt
@@ -1,0 +1,15 @@
+package com.meneses.budgethunter.fakes.manager
+
+import com.meneses.budgethunter.commons.platform.CameraManager
+
+class FakeCameraManager : CameraManager {
+    var callback: ((ByteArray?) -> Unit)? = null
+
+    override fun takePhoto(onResult: (ByteArray?) -> Unit) {
+        callback = onResult
+    }
+
+    fun simulatePhotoTaken(data: ByteArray?) {
+        callback?.invoke(data)
+    }
+}

--- a/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/fakes/manager/FakeFileManager.kt
+++ b/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/fakes/manager/FakeFileManager.kt
@@ -1,0 +1,19 @@
+package com.meneses.budgethunter.fakes.manager
+
+import com.meneses.budgethunter.commons.data.FileManager
+
+class FakeFileManager : FileManager {
+    val savedFiles = mutableListOf<ByteArray>()
+    val deletedFiles = mutableListOf<String>()
+
+    override suspend fun saveFile(fileData: ByteArray): String {
+        savedFiles.add(fileData)
+        return "/saved/file_${savedFiles.size}.pdf"
+    }
+
+    override fun deleteFile(filePath: String) {
+        deletedFiles.add(filePath)
+    }
+
+    override fun createUri(filePath: String): String = "file://$filePath"
+}

--- a/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/fakes/manager/FakeFileManager.kt
+++ b/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/fakes/manager/FakeFileManager.kt
@@ -1,19 +1,23 @@
 package com.meneses.budgethunter.fakes.manager
 
+import com.meneses.budgethunter.commons.data.FileData
 import com.meneses.budgethunter.commons.data.IFileManager
 
 class FakeFileManager : IFileManager {
-    val savedFiles = mutableListOf<ByteArray>()
+    val savedFiles = mutableListOf<FileData>()
     val deletedFiles = mutableListOf<String>()
 
-    override suspend fun saveFile(fileData: ByteArray): String {
+    override fun saveFile(fileData: FileData): String {
         savedFiles.add(fileData)
         return "/saved/file_${savedFiles.size}.pdf"
     }
 
-    override fun deleteFile(filePath: String) {
+    override fun deleteFile(filePath: String): Boolean {
         deletedFiles.add(filePath)
+        return true
     }
 
     override fun createUri(filePath: String): String = "file://$filePath"
+
+    override fun fileExists(filePath: String): Boolean = true
 }

--- a/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/fakes/manager/FakeFileManager.kt
+++ b/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/fakes/manager/FakeFileManager.kt
@@ -1,8 +1,8 @@
 package com.meneses.budgethunter.fakes.manager
 
-import com.meneses.budgethunter.commons.data.FileManager
+import com.meneses.budgethunter.commons.data.IFileManager
 
-class FakeFileManager : FileManager {
+class FakeFileManager : IFileManager {
     val savedFiles = mutableListOf<ByteArray>()
     val deletedFiles = mutableListOf<String>()
 

--- a/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/fakes/manager/FakeFilePickerManager.kt
+++ b/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/fakes/manager/FakeFilePickerManager.kt
@@ -1,15 +1,24 @@
 package com.meneses.budgethunter.fakes.manager
 
+import com.meneses.budgethunter.commons.data.FileData
 import com.meneses.budgethunter.commons.platform.FilePickerManager
 
 class FakeFilePickerManager : FilePickerManager {
-    var callback: ((ByteArray?) -> Unit)? = null
+    var callback: ((FileData?) -> Unit)? = null
 
-    override fun pickFile(onResult: (ByteArray?) -> Unit) {
+    override fun pickFile(mimeTypes: Array<String>, onResult: (FileData?) -> Unit) {
         callback = onResult
     }
 
     fun simulateFilePicked(data: ByteArray?) {
-        callback?.invoke(data)
+        val fileData = data?.let {
+            FileData(
+                data = it,
+                filename = "document.pdf",
+                mimeType = "application/pdf",
+                directory = "/tmp"
+            )
+        }
+        callback?.invoke(fileData)
     }
 }

--- a/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/fakes/manager/FakeFilePickerManager.kt
+++ b/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/fakes/manager/FakeFilePickerManager.kt
@@ -1,0 +1,15 @@
+package com.meneses.budgethunter.fakes.manager
+
+import com.meneses.budgethunter.commons.platform.FilePickerManager
+
+class FakeFilePickerManager : FilePickerManager {
+    var callback: ((ByteArray?) -> Unit)? = null
+
+    override fun pickFile(onResult: (ByteArray?) -> Unit) {
+        callback = onResult
+    }
+
+    fun simulateFilePicked(data: ByteArray?) {
+        callback?.invoke(data)
+    }
+}

--- a/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/fakes/manager/FakeNotificationManager.kt
+++ b/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/fakes/manager/FakeNotificationManager.kt
@@ -1,0 +1,16 @@
+package com.meneses.budgethunter.fakes.manager
+
+import com.meneses.budgethunter.commons.platform.NotificationManager
+
+class FakeNotificationManager : NotificationManager {
+    val notifications = mutableListOf<Pair<String, String>>()
+    val toasts = mutableListOf<String>()
+
+    override fun showNotification(title: String, message: String) {
+        notifications.add(title to message)
+    }
+
+    override fun showToast(message: String) {
+        toasts.add(message)
+    }
+}

--- a/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/fakes/manager/FakePermissionsManager.kt
+++ b/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/fakes/manager/FakePermissionsManager.kt
@@ -1,0 +1,21 @@
+package com.meneses.budgethunter.fakes.manager
+
+import com.meneses.budgethunter.commons.platform.PermissionsManager
+
+class FakePermissionsManager : PermissionsManager {
+    var hasSms = false
+    var shouldShowRationale = false
+    var appSettingsOpened = false
+    var permissionRequested = false
+    var grantPermission = false
+
+    override fun hasSmsPermission(): Boolean = hasSms
+    override fun shouldShowSMSPermissionRationale(): Boolean = shouldShowRationale
+    override fun requestSmsPermissions(onResult: (Boolean) -> Unit) {
+        permissionRequested = true
+        onResult(grantPermission)
+    }
+    override fun openAppSettings() {
+        appSettingsOpened = true
+    }
+}

--- a/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/fakes/manager/FakePermissionsManager.kt
+++ b/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/fakes/manager/FakePermissionsManager.kt
@@ -1,8 +1,8 @@
 package com.meneses.budgethunter.fakes.manager
 
-import com.meneses.budgethunter.commons.platform.PermissionsManager
+import com.meneses.budgethunter.commons.platform.IPermissionsManager
 
-class FakePermissionsManager : PermissionsManager {
+class FakePermissionsManager : IPermissionsManager {
     var hasSms = false
     var shouldShowRationale = false
     var appSettingsOpened = false

--- a/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/fakes/manager/FakePreferencesManager.kt
+++ b/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/fakes/manager/FakePreferencesManager.kt
@@ -1,8 +1,8 @@
 package com.meneses.budgethunter.fakes.manager
 
-import com.meneses.budgethunter.commons.data.PreferencesManager
+import com.meneses.budgethunter.commons.data.IPreferencesManager
 
-class FakePreferencesManager : PreferencesManager {
+class FakePreferencesManager : IPreferencesManager {
     private var smsReadingEnabled = false
     private var aiProcessingEnabled = false
     private var defaultBudgetId = -1

--- a/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/fakes/manager/FakePreferencesManager.kt
+++ b/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/fakes/manager/FakePreferencesManager.kt
@@ -1,0 +1,34 @@
+package com.meneses.budgethunter.fakes.manager
+
+import com.meneses.budgethunter.commons.data.PreferencesManager
+
+class FakePreferencesManager : PreferencesManager {
+    private var smsReadingEnabled = false
+    private var aiProcessingEnabled = false
+    private var defaultBudgetId = -1
+    private var selectedBankIds = emptySet<String>()
+
+    var aiEnabled: Boolean
+        get() = aiProcessingEnabled
+        set(value) { aiProcessingEnabled = value }
+
+    override suspend fun isSmsReadingEnabled(): Boolean = smsReadingEnabled
+    override suspend fun setSmsReadingEnabled(enabled: Boolean) {
+        smsReadingEnabled = enabled
+    }
+
+    override suspend fun isAiProcessingEnabled(): Boolean = aiProcessingEnabled
+    override suspend fun setAiProcessingEnabled(enabled: Boolean) {
+        aiProcessingEnabled = enabled
+    }
+
+    override suspend fun getDefaultBudgetId(): Int = defaultBudgetId
+    override suspend fun setDefaultBudgetId(budgetId: Int) {
+        defaultBudgetId = budgetId
+    }
+
+    override suspend fun getSelectedBankIds(): Set<String> = selectedBankIds
+    override suspend fun setSelectedBankIds(bankIds: Set<String>) {
+        selectedBankIds = bankIds
+    }
+}

--- a/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/fakes/manager/FakeShareManager.kt
+++ b/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/fakes/manager/FakeShareManager.kt
@@ -5,7 +5,7 @@ import com.meneses.budgethunter.commons.platform.ShareManager
 class FakeShareManager : ShareManager {
     val sharedFiles = mutableListOf<String>()
 
-    override suspend fun shareFile(filePath: String) {
+    override fun shareFile(filePath: String, mimeTypes: Array<String>) {
         sharedFiles.add(filePath)
     }
 }

--- a/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/fakes/manager/FakeShareManager.kt
+++ b/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/fakes/manager/FakeShareManager.kt
@@ -1,0 +1,11 @@
+package com.meneses.budgethunter.fakes.manager
+
+import com.meneses.budgethunter.commons.platform.ShareManager
+
+class FakeShareManager : ShareManager {
+    val sharedFiles = mutableListOf<String>()
+
+    override suspend fun shareFile(filePath: String) {
+        sharedFiles.add(filePath)
+    }
+}

--- a/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/fakes/repository/FakeBudgetDetailRepository.kt
+++ b/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/fakes/repository/FakeBudgetDetailRepository.kt
@@ -12,7 +12,7 @@ class FakeBudgetDetailRepository : IBudgetDetailRepository {
     val deletedEntryIds = mutableListOf<List<Int>>()
     val updatedAmounts = mutableListOf<Double>()
 
-    override suspend fun getBudgetDetailById(budgetId: Int): Flow<BudgetDetail> {
+    override fun getBudgetDetailById(budgetId: Int): Flow<BudgetDetail> {
         return flowOf(cachedDetail)
     }
 
@@ -21,9 +21,9 @@ class FakeBudgetDetailRepository : IBudgetDetailRepository {
     override suspend fun getAllFilteredBy(filter: BudgetEntryFilter): BudgetDetail {
         return cachedDetail.copy(
             entries = cachedDetail.entries.filter {
-                when (filter) {
-                    is BudgetEntryFilter.ByCategory -> it.category == filter.category
-                    is BudgetEntryFilter.ByType -> it.type == filter.type
+                when {
+                    filter.category != null -> it.category == filter.category
+                    filter.type != null -> it.type == filter.type
                     else -> true
                 }
             }

--- a/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/fakes/repository/FakeBudgetDetailRepository.kt
+++ b/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/fakes/repository/FakeBudgetDetailRepository.kt
@@ -2,7 +2,6 @@ package com.meneses.budgethunter.fakes.repository
 
 import com.meneses.budgethunter.budgetDetail.data.BudgetDetailRepository
 import com.meneses.budgethunter.budgetDetail.domain.BudgetDetail
-import com.meneses.budgethunter.budgetEntry.domain.BudgetEntry
 import com.meneses.budgethunter.budgetEntry.domain.BudgetEntryFilter
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf

--- a/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/fakes/repository/FakeBudgetDetailRepository.kt
+++ b/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/fakes/repository/FakeBudgetDetailRepository.kt
@@ -1,12 +1,12 @@
 package com.meneses.budgethunter.fakes.repository
 
-import com.meneses.budgethunter.budgetDetail.data.BudgetDetailRepository
+import com.meneses.budgethunter.budgetDetail.data.IBudgetDetailRepository
 import com.meneses.budgethunter.budgetDetail.domain.BudgetDetail
 import com.meneses.budgethunter.budgetEntry.domain.BudgetEntryFilter
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
 
-class FakeBudgetDetailRepository : BudgetDetailRepository {
+class FakeBudgetDetailRepository : IBudgetDetailRepository {
     var cachedDetail = BudgetDetail()
     val deletedBudgetIds = mutableListOf<Int>()
     val deletedEntryIds = mutableListOf<List<Int>>()

--- a/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/fakes/repository/FakeBudgetDetailRepository.kt
+++ b/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/fakes/repository/FakeBudgetDetailRepository.kt
@@ -1,0 +1,45 @@
+package com.meneses.budgethunter.fakes.repository
+
+import com.meneses.budgethunter.budgetDetail.data.BudgetDetailRepository
+import com.meneses.budgethunter.budgetDetail.domain.BudgetDetail
+import com.meneses.budgethunter.budgetEntry.domain.BudgetEntry
+import com.meneses.budgethunter.budgetEntry.domain.BudgetEntryFilter
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+
+class FakeBudgetDetailRepository : BudgetDetailRepository {
+    var cachedDetail = BudgetDetail()
+    val deletedBudgetIds = mutableListOf<Int>()
+    val deletedEntryIds = mutableListOf<List<Int>>()
+    val updatedAmounts = mutableListOf<Double>()
+
+    override suspend fun getBudgetDetailById(budgetId: Int): Flow<BudgetDetail> {
+        return flowOf(cachedDetail)
+    }
+
+    override suspend fun getCachedDetail(): BudgetDetail = cachedDetail
+
+    override suspend fun getAllFilteredBy(filter: BudgetEntryFilter): BudgetDetail {
+        return cachedDetail.copy(
+            entries = cachedDetail.entries.filter {
+                when (filter) {
+                    is BudgetEntryFilter.ByCategory -> it.category == filter.category
+                    is BudgetEntryFilter.ByType -> it.type == filter.type
+                    else -> true
+                }
+            }
+        )
+    }
+
+    override suspend fun deleteBudget(budgetId: Int) {
+        deletedBudgetIds.add(budgetId)
+    }
+
+    override suspend fun deleteEntriesByIds(ids: List<Int>) {
+        deletedEntryIds.add(ids)
+    }
+
+    override suspend fun updateBudgetAmount(amount: Double) {
+        updatedAmounts.add(amount)
+    }
+}

--- a/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/fakes/repository/FakeBudgetEntryRepository.kt
+++ b/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/fakes/repository/FakeBudgetEntryRepository.kt
@@ -2,10 +2,16 @@ package com.meneses.budgethunter.fakes.repository
 
 import com.meneses.budgethunter.budgetEntry.data.IBudgetEntryRepository
 import com.meneses.budgethunter.budgetEntry.domain.BudgetEntry
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
 
 class FakeBudgetEntryRepository : IBudgetEntryRepository {
     val createdEntries = mutableListOf<BudgetEntry>()
     val updatedEntries = mutableListOf<BudgetEntry>()
+
+    override fun getAllByBudgetId(budgetId: Long): Flow<List<BudgetEntry>> {
+        return flowOf(emptyList())
+    }
 
     override suspend fun create(budgetEntry: BudgetEntry) {
         createdEntries.add(budgetEntry)

--- a/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/fakes/repository/FakeBudgetEntryRepository.kt
+++ b/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/fakes/repository/FakeBudgetEntryRepository.kt
@@ -1,9 +1,9 @@
 package com.meneses.budgethunter.fakes.repository
 
-import com.meneses.budgethunter.budgetEntry.data.BudgetEntryRepository
+import com.meneses.budgethunter.budgetEntry.data.IBudgetEntryRepository
 import com.meneses.budgethunter.budgetEntry.domain.BudgetEntry
 
-class FakeBudgetEntryRepository : BudgetEntryRepository {
+class FakeBudgetEntryRepository : IBudgetEntryRepository {
     val createdEntries = mutableListOf<BudgetEntry>()
     val updatedEntries = mutableListOf<BudgetEntry>()
 

--- a/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/fakes/repository/FakeBudgetEntryRepository.kt
+++ b/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/fakes/repository/FakeBudgetEntryRepository.kt
@@ -1,0 +1,17 @@
+package com.meneses.budgethunter.fakes.repository
+
+import com.meneses.budgethunter.budgetEntry.data.BudgetEntryRepository
+import com.meneses.budgethunter.budgetEntry.domain.BudgetEntry
+
+class FakeBudgetEntryRepository : BudgetEntryRepository {
+    val createdEntries = mutableListOf<BudgetEntry>()
+    val updatedEntries = mutableListOf<BudgetEntry>()
+
+    override suspend fun create(budgetEntry: BudgetEntry) {
+        createdEntries.add(budgetEntry)
+    }
+
+    override suspend fun update(budgetEntry: BudgetEntry) {
+        updatedEntries.add(budgetEntry)
+    }
+}

--- a/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/fakes/repository/FakeBudgetRepository.kt
+++ b/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/fakes/repository/FakeBudgetRepository.kt
@@ -1,0 +1,51 @@
+package com.meneses.budgethunter.fakes.repository
+
+import com.meneses.budgethunter.budgetList.data.BudgetRepository
+import com.meneses.budgethunter.budgetList.domain.Budget
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+class FakeBudgetRepository : BudgetRepository {
+    private val _budgets = MutableStateFlow<List<Budget>>(emptyList())
+    override val budgets: StateFlow<List<Budget>> = _budgets
+
+    val createdBudgets = mutableListOf<Budget>()
+    val updatedBudgets = mutableListOf<Budget>()
+    private val budgetCache = mutableListOf<Budget>()
+
+    fun emitBudgets(budgetList: List<Budget>) {
+        budgetCache.clear()
+        budgetCache.addAll(budgetList)
+        _budgets.value = budgetList
+    }
+
+    override suspend fun create(budget: Budget): Budget {
+        val newBudget = budget.copy(id = (budgetCache.maxOfOrNull { it.id } ?: 0) + 1)
+        createdBudgets.add(newBudget)
+        budgetCache.add(newBudget)
+        _budgets.value = budgetCache.toList()
+        return newBudget
+    }
+
+    override suspend fun update(budget: Budget) {
+        updatedBudgets.add(budget)
+        val index = budgetCache.indexOfFirst { it.id == budget.id }
+        if (index >= 0) {
+            budgetCache[index] = budget
+            _budgets.value = budgetCache.toList()
+        }
+    }
+
+    override suspend fun getById(id: Int): Budget? {
+        return budgetCache.find { it.id == id }
+    }
+
+    override suspend fun getAllCached(): List<Budget> = budgetCache.toList()
+
+    override suspend fun getAllFilteredBy(filter: Any?): List<Budget> = budgetCache.toList()
+
+    fun setBudgets(budgets: List<Budget>) {
+        budgetCache.clear()
+        budgetCache.addAll(budgets)
+    }
+}

--- a/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/fakes/repository/FakeBudgetRepository.kt
+++ b/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/fakes/repository/FakeBudgetRepository.kt
@@ -2,12 +2,13 @@ package com.meneses.budgethunter.fakes.repository
 
 import com.meneses.budgethunter.budgetList.data.IBudgetRepository
 import com.meneses.budgethunter.budgetList.domain.Budget
+import com.meneses.budgethunter.budgetList.domain.BudgetFilter
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
 
 class FakeBudgetRepository : IBudgetRepository {
     private val _budgets = MutableStateFlow<List<Budget>>(emptyList())
-    override val budgets: StateFlow<List<Budget>> = _budgets
+    override val budgets: Flow<List<Budget>> = _budgets
 
     val createdBudgets = mutableListOf<Budget>()
     val updatedBudgets = mutableListOf<Budget>()
@@ -42,7 +43,7 @@ class FakeBudgetRepository : IBudgetRepository {
 
     override suspend fun getAllCached(): List<Budget> = budgetCache.toList()
 
-    override suspend fun getAllFilteredBy(filter: Any?): List<Budget> = budgetCache.toList()
+    override suspend fun getAllFilteredBy(filter: BudgetFilter): List<Budget> = budgetCache.toList()
 
     fun setBudgets(budgets: List<Budget>) {
         budgetCache.clear()

--- a/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/fakes/repository/FakeBudgetRepository.kt
+++ b/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/fakes/repository/FakeBudgetRepository.kt
@@ -1,11 +1,11 @@
 package com.meneses.budgethunter.fakes.repository
 
-import com.meneses.budgethunter.budgetList.data.BudgetRepository
+import com.meneses.budgethunter.budgetList.data.IBudgetRepository
 import com.meneses.budgethunter.budgetList.domain.Budget
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 
-class FakeBudgetRepository : BudgetRepository {
+class FakeBudgetRepository : IBudgetRepository {
     private val _budgets = MutableStateFlow<List<Budget>>(emptyList())
     override val budgets: StateFlow<List<Budget>> = _budgets
 

--- a/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/fakes/usecase/FakeCreateBudgetEntryFromImageUseCase.kt
+++ b/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/fakes/usecase/FakeCreateBudgetEntryFromImageUseCase.kt
@@ -1,9 +1,9 @@
 package com.meneses.budgethunter.fakes.usecase
 
-import com.meneses.budgethunter.budgetEntry.application.CreateBudgetEntryFromImageUseCase
+import com.meneses.budgethunter.budgetEntry.application.ICreateBudgetEntryFromImageUseCase
 import com.meneses.budgethunter.budgetEntry.domain.BudgetEntry
 
-class FakeCreateBudgetEntryFromImageUseCase : CreateBudgetEntryFromImageUseCase(null!!, null!!) {
+class FakeCreateBudgetEntryFromImageUseCase : ICreateBudgetEntryFromImageUseCase {
     var processedEntry: BudgetEntry? = null
 
     override suspend fun execute(imageUri: String, budgetEntry: BudgetEntry): BudgetEntry {

--- a/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/fakes/usecase/FakeCreateBudgetEntryFromImageUseCase.kt
+++ b/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/fakes/usecase/FakeCreateBudgetEntryFromImageUseCase.kt
@@ -1,0 +1,12 @@
+package com.meneses.budgethunter.fakes.usecase
+
+import com.meneses.budgethunter.budgetEntry.application.CreateBudgetEntryFromImageUseCase
+import com.meneses.budgethunter.budgetEntry.domain.BudgetEntry
+
+class FakeCreateBudgetEntryFromImageUseCase : CreateBudgetEntryFromImageUseCase(null!!, null!!) {
+    var processedEntry: BudgetEntry? = null
+
+    override suspend fun execute(imageUri: String, budgetEntry: BudgetEntry): BudgetEntry {
+        return processedEntry ?: budgetEntry.copy(description = "AI Processed")
+    }
+}

--- a/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/fakes/usecase/FakeDeleteBudgetUseCase.kt
+++ b/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/fakes/usecase/FakeDeleteBudgetUseCase.kt
@@ -1,0 +1,11 @@
+package com.meneses.budgethunter.fakes.usecase
+
+import com.meneses.budgethunter.budgetList.application.DeleteBudgetUseCase
+
+class FakeDeleteBudgetUseCase : DeleteBudgetUseCase(null!!, null!!, null!!) {
+    val deletedBudgetIds = mutableListOf<Long>()
+
+    override suspend fun execute(budgetId: Long) {
+        deletedBudgetIds.add(budgetId)
+    }
+}

--- a/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/fakes/usecase/FakeDeleteBudgetUseCase.kt
+++ b/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/fakes/usecase/FakeDeleteBudgetUseCase.kt
@@ -1,8 +1,8 @@
 package com.meneses.budgethunter.fakes.usecase
 
-import com.meneses.budgethunter.budgetList.application.DeleteBudgetUseCase
+import com.meneses.budgethunter.budgetList.application.IDeleteBudgetUseCase
 
-class FakeDeleteBudgetUseCase : DeleteBudgetUseCase(null!!, null!!, null!!) {
+class FakeDeleteBudgetUseCase : IDeleteBudgetUseCase {
     val deletedBudgetIds = mutableListOf<Long>()
 
     override suspend fun execute(budgetId: Long) {

--- a/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/fakes/usecase/FakeDuplicateBudgetUseCase.kt
+++ b/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/fakes/usecase/FakeDuplicateBudgetUseCase.kt
@@ -1,0 +1,12 @@
+package com.meneses.budgethunter.fakes.usecase
+
+import com.meneses.budgethunter.budgetList.application.DuplicateBudgetUseCase
+import com.meneses.budgethunter.budgetList.domain.Budget
+
+class FakeDuplicateBudgetUseCase : DuplicateBudgetUseCase(null!!, null!!, null!!) {
+    val duplicatedBudgets = mutableListOf<Budget>()
+
+    override suspend fun execute(budget: Budget) {
+        duplicatedBudgets.add(budget)
+    }
+}

--- a/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/fakes/usecase/FakeDuplicateBudgetUseCase.kt
+++ b/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/fakes/usecase/FakeDuplicateBudgetUseCase.kt
@@ -6,7 +6,8 @@ import com.meneses.budgethunter.budgetList.domain.Budget
 class FakeDuplicateBudgetUseCase : IDuplicateBudgetUseCase {
     val duplicatedBudgets = mutableListOf<Budget>()
 
-    override suspend fun execute(budget: Budget) {
+    override suspend fun execute(budget: Budget): Budget {
         duplicatedBudgets.add(budget)
+        return budget.copy(id = budget.id + 1000)
     }
 }

--- a/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/fakes/usecase/FakeDuplicateBudgetUseCase.kt
+++ b/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/fakes/usecase/FakeDuplicateBudgetUseCase.kt
@@ -1,9 +1,9 @@
 package com.meneses.budgethunter.fakes.usecase
 
-import com.meneses.budgethunter.budgetList.application.DuplicateBudgetUseCase
+import com.meneses.budgethunter.budgetList.application.IDuplicateBudgetUseCase
 import com.meneses.budgethunter.budgetList.domain.Budget
 
-class FakeDuplicateBudgetUseCase : DuplicateBudgetUseCase(null!!, null!!, null!!) {
+class FakeDuplicateBudgetUseCase : IDuplicateBudgetUseCase {
     val duplicatedBudgets = mutableListOf<Budget>()
 
     override suspend fun execute(budget: Budget) {

--- a/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/fakes/usecase/FakeGetTotalsPerCategoryUseCase.kt
+++ b/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/fakes/usecase/FakeGetTotalsPerCategoryUseCase.kt
@@ -1,11 +1,16 @@
 package com.meneses.budgethunter.fakes.usecase
 
+import com.meneses.budgethunter.budgetEntry.domain.BudgetEntry
 import com.meneses.budgethunter.budgetMetrics.application.IGetTotalsPerCategoryUseCase
 
 class FakeGetTotalsPerCategoryUseCase(
     private val totalsMap: Map<String, Double> = emptyMap()
 ) : IGetTotalsPerCategoryUseCase {
-    override suspend fun execute(): Map<String, Double> {
-        return totalsMap
+    override suspend fun execute(): Map<BudgetEntry.Category, Double> {
+        // Convert String keys to BudgetEntry.Category
+        return totalsMap.mapKeys { (key, _) ->
+            BudgetEntry.Category.entries.firstOrNull { it.name == key }
+                ?: BudgetEntry.Category.OTHER
+        }
     }
 }

--- a/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/fakes/usecase/FakeGetTotalsPerCategoryUseCase.kt
+++ b/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/fakes/usecase/FakeGetTotalsPerCategoryUseCase.kt
@@ -4,13 +4,9 @@ import com.meneses.budgethunter.budgetEntry.domain.BudgetEntry
 import com.meneses.budgethunter.budgetMetrics.application.IGetTotalsPerCategoryUseCase
 
 class FakeGetTotalsPerCategoryUseCase(
-    private val totalsMap: Map<String, Double> = emptyMap()
+    private val totalsMap: Map<BudgetEntry.Category, Double> = emptyMap()
 ) : IGetTotalsPerCategoryUseCase {
     override suspend fun execute(): Map<BudgetEntry.Category, Double> {
-        // Convert String keys to BudgetEntry.Category
-        return totalsMap.mapKeys { (key, _) ->
-            BudgetEntry.Category.entries.firstOrNull { it.name == key }
-                ?: BudgetEntry.Category.OTHER
-        }
+        return totalsMap
     }
 }

--- a/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/fakes/usecase/FakeGetTotalsPerCategoryUseCase.kt
+++ b/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/fakes/usecase/FakeGetTotalsPerCategoryUseCase.kt
@@ -1,14 +1,10 @@
 package com.meneses.budgethunter.fakes.usecase
 
-import com.meneses.budgethunter.budgetMetrics.application.GetTotalsPerCategoryUseCase
-import kotlinx.coroutines.Dispatchers
+import com.meneses.budgethunter.budgetMetrics.application.IGetTotalsPerCategoryUseCase
 
 class FakeGetTotalsPerCategoryUseCase(
     private val totalsMap: Map<String, Double> = emptyMap()
-) : GetTotalsPerCategoryUseCase(
-    budgetDetailRepository = null!!,
-    ioDispatcher = Dispatchers.Default
-) {
+) : IGetTotalsPerCategoryUseCase {
     override suspend fun execute(): Map<String, Double> {
         return totalsMap
     }

--- a/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/fakes/usecase/FakeGetTotalsPerCategoryUseCase.kt
+++ b/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/fakes/usecase/FakeGetTotalsPerCategoryUseCase.kt
@@ -1,0 +1,15 @@
+package com.meneses.budgethunter.fakes.usecase
+
+import com.meneses.budgethunter.budgetMetrics.application.GetTotalsPerCategoryUseCase
+import kotlinx.coroutines.Dispatchers
+
+class FakeGetTotalsPerCategoryUseCase(
+    private val totalsMap: Map<String, Double> = emptyMap()
+) : GetTotalsPerCategoryUseCase(
+    budgetDetailRepository = null!!,
+    ioDispatcher = Dispatchers.Default
+) {
+    override suspend fun execute(): Map<String, Double> {
+        return totalsMap
+    }
+}

--- a/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/fakes/usecase/FakeValidateFilePathUseCase.kt
+++ b/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/fakes/usecase/FakeValidateFilePathUseCase.kt
@@ -1,8 +1,8 @@
 package com.meneses.budgethunter.fakes.usecase
 
-import com.meneses.budgethunter.commons.application.ValidateFilePathUseCase
+import com.meneses.budgethunter.commons.application.IValidateFilePathUseCase
 
-class FakeValidateFilePathUseCase : ValidateFilePathUseCase(null!!) {
+class FakeValidateFilePathUseCase : IValidateFilePathUseCase {
     var validPath: String? = "/valid/path.pdf"
 
     override suspend fun execute(filePath: String): String? = validPath

--- a/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/fakes/usecase/FakeValidateFilePathUseCase.kt
+++ b/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/fakes/usecase/FakeValidateFilePathUseCase.kt
@@ -5,5 +5,5 @@ import com.meneses.budgethunter.commons.application.IValidateFilePathUseCase
 class FakeValidateFilePathUseCase : IValidateFilePathUseCase {
     var validPath: String? = "/valid/path.pdf"
 
-    override suspend fun execute(filePath: String): String? = validPath
+    override suspend fun execute(filePath: String?): String? = validPath
 }

--- a/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/fakes/usecase/FakeValidateFilePathUseCase.kt
+++ b/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/fakes/usecase/FakeValidateFilePathUseCase.kt
@@ -1,0 +1,9 @@
+package com.meneses.budgethunter.fakes.usecase
+
+import com.meneses.budgethunter.commons.application.ValidateFilePathUseCase
+
+class FakeValidateFilePathUseCase : ValidateFilePathUseCase(null!!) {
+    var validPath: String? = "/valid/path.pdf"
+
+    override suspend fun execute(filePath: String): String? = validPath
+}

--- a/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/settings/SettingsViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/settings/SettingsViewModelTest.kt
@@ -1,13 +1,11 @@
 package com.meneses.budgethunter.settings
 
-import com.meneses.budgethunter.budgetList.data.BudgetRepository
 import com.meneses.budgethunter.budgetList.domain.Budget
-import com.meneses.budgethunter.commons.data.PreferencesManager
-import com.meneses.budgethunter.commons.platform.PermissionsManager
+import com.meneses.budgethunter.fakes.manager.FakePermissionsManager
+import com.meneses.budgethunter.fakes.manager.FakePreferencesManager
+import com.meneses.budgethunter.fakes.repository.FakeBudgetRepository
 import com.meneses.budgethunter.settings.application.SettingsEvent
 import com.meneses.budgethunter.sms.domain.BankSmsConfig
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -15,67 +13,6 @@ import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class SettingsViewModelTest {
-
-    private class FakePreferencesManager : PreferencesManager {
-        private var smsReadingEnabled = false
-        private var aiProcessingEnabled = false
-        private var defaultBudgetId = -1
-        private var selectedBankIds = emptySet<String>()
-
-        override suspend fun isSmsReadingEnabled(): Boolean = smsReadingEnabled
-        override suspend fun setSmsReadingEnabled(enabled: Boolean) {
-            smsReadingEnabled = enabled
-        }
-
-        override suspend fun isAiProcessingEnabled(): Boolean = aiProcessingEnabled
-        override suspend fun setAiProcessingEnabled(enabled: Boolean) {
-            aiProcessingEnabled = enabled
-        }
-
-        override suspend fun getDefaultBudgetId(): Int = defaultBudgetId
-        override suspend fun setDefaultBudgetId(budgetId: Int) {
-            defaultBudgetId = budgetId
-        }
-
-        override suspend fun getSelectedBankIds(): Set<String> = selectedBankIds
-        override suspend fun setSelectedBankIds(bankIds: Set<String>) {
-            selectedBankIds = bankIds
-        }
-    }
-
-    private class FakeBudgetRepository : BudgetRepository {
-        private val budgetCache = mutableListOf<Budget>()
-        override val budgets: StateFlow<List<Budget>> = MutableStateFlow(emptyList())
-
-        fun setBudgets(budgets: List<Budget>) {
-            budgetCache.clear()
-            budgetCache.addAll(budgets)
-        }
-
-        override suspend fun create(budget: Budget): Budget = budget
-        override suspend fun update(budget: Budget) {}
-        override suspend fun getById(id: Int): Budget? = budgetCache.find { it.id == id }
-        override suspend fun getAllCached(): List<Budget> = budgetCache.toList()
-        override suspend fun getAllFilteredBy(filter: Any?): List<Budget> = budgetCache.toList()
-    }
-
-    private class FakePermissionsManager : PermissionsManager {
-        var hasSms = false
-        var shouldShowRationale = false
-        var appSettingsOpened = false
-        var permissionRequested = false
-        var grantPermission = false
-
-        override fun hasSmsPermission(): Boolean = hasSms
-        override fun shouldShowSMSPermissionRationale(): Boolean = shouldShowRationale
-        override fun requestSmsPermissions(onResult: (Boolean) -> Unit) {
-            permissionRequested = true
-            onResult(grantPermission)
-        }
-        override fun openAppSettings() {
-            appSettingsOpened = true
-        }
-    }
 
     @Test
     fun `initial state loads settings on initialization`() = runTest {

--- a/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/settings/SettingsViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/settings/SettingsViewModelTest.kt
@@ -33,16 +33,16 @@ class SettingsViewModelTest {
 
     @Test
     fun `loadSettings loads default budget`() = runTest {
-        val preferences: IPreferencesManager = FakePreferencesManager()
-        preferences.setDefaultBudgetId(1)
+        val fakePreferences = FakePreferencesManager()
+        fakePreferences.setDefaultBudgetId(1)
 
-        val repository: IBudgetRepository = FakeBudgetRepository()
+        val fakeRepository = FakeBudgetRepository()
         val budget = Budget(id = 1, name = "Default Budget", amount = 100.0)
-        repository.setBudgets(listOf(budget))
+        fakeRepository.setBudgets(listOf(budget))
 
-        val permissions: IPermissionsManager = FakePermissionsManager()
+        val fakePermissions = FakePermissionsManager()
 
-        val viewModel = SettingsViewModel(preferences, repository, permissions)
+        val viewModel = SettingsViewModel(fakePreferences, fakeRepository, fakePermissions)
 
         kotlinx.coroutines.delay(100)
 
@@ -52,13 +52,13 @@ class SettingsViewModelTest {
 
     @Test
     fun `loadSettings loads sms reading state`() = runTest {
-        val preferences: IPreferencesManager = FakePreferencesManager()
-        preferences.setSmsReadingEnabled(true)
+        val fakePreferences = FakePreferencesManager()
+        fakePreferences.setSmsReadingEnabled(true)
 
-        val repository: IBudgetRepository = FakeBudgetRepository()
-        val permissions: IPermissionsManager = FakePermissionsManager()
+        val fakeRepository = FakeBudgetRepository()
+        val fakePermissions = FakePermissionsManager()
 
-        val viewModel = SettingsViewModel(preferences, repository, permissions)
+        val viewModel = SettingsViewModel(fakePreferences, fakeRepository, fakePermissions)
 
         kotlinx.coroutines.delay(100)
 
@@ -68,13 +68,13 @@ class SettingsViewModelTest {
 
     @Test
     fun `loadSettings loads ai processing state`() = runTest {
-        val preferences: IPreferencesManager = FakePreferencesManager()
-        preferences.setAiProcessingEnabled(true)
+        val fakePreferences = FakePreferencesManager()
+        fakePreferences.setAiProcessingEnabled(true)
 
-        val repository: IBudgetRepository = FakeBudgetRepository()
-        val permissions: IPermissionsManager = FakePermissionsManager()
+        val fakeRepository = FakeBudgetRepository()
+        val fakePermissions = FakePermissionsManager()
 
-        val viewModel = SettingsViewModel(preferences, repository, permissions)
+        val viewModel = SettingsViewModel(fakePreferences, fakeRepository, fakePermissions)
 
         kotlinx.coroutines.delay(100)
 
@@ -84,48 +84,48 @@ class SettingsViewModelTest {
 
     @Test
     fun `toggleSmsReading enables sms reading`() = runTest {
-        val preferences: IPreferencesManager = FakePreferencesManager()
-        val repository: IBudgetRepository = FakeBudgetRepository()
-        val permissions: IPermissionsManager = FakePermissionsManager()
-        permissions.hasSms = true
+        val fakePreferences = FakePreferencesManager()
+        val fakeRepository = FakeBudgetRepository()
+        val fakePermissions = FakePermissionsManager()
+        fakePermissions.hasSms = true
 
-        val viewModel = SettingsViewModel(preferences, repository, permissions)
+        val viewModel = SettingsViewModel(fakePreferences, fakeRepository, fakePermissions)
 
         kotlinx.coroutines.delay(100)
         viewModel.sendEvent(SettingsEvent.ToggleSmsReading(true))
         kotlinx.coroutines.delay(100)
 
-        assertTrue(preferences.isSmsReadingEnabled())
+        assertTrue(fakePreferences.isSmsReadingEnabled())
         assertTrue(viewModel.uiState.value.isSmsReadingEnabled)
     }
 
     @Test
     fun `toggleSmsReading requests permission when not granted`() = runTest {
-        val preferences: IPreferencesManager = FakePreferencesManager()
-        val repository: IBudgetRepository = FakeBudgetRepository()
-        val permissions: IPermissionsManager = FakePermissionsManager()
-        permissions.hasSms = false
-        permissions.grantPermission = true
+        val fakePreferences = FakePreferencesManager()
+        val fakeRepository = FakeBudgetRepository()
+        val fakePermissions = FakePermissionsManager()
+        fakePermissions.hasSms = false
+        fakePermissions.grantPermission = true
 
-        val viewModel = SettingsViewModel(preferences, repository, permissions)
+        val viewModel = SettingsViewModel(fakePreferences, fakeRepository, fakePermissions)
 
         kotlinx.coroutines.delay(100)
         viewModel.sendEvent(SettingsEvent.ToggleSmsReading(true))
         kotlinx.coroutines.delay(100)
 
-        assertTrue(permissions.permissionRequested)
+        assertTrue(fakePermissions.permissionRequested)
         assertTrue(viewModel.uiState.value.hasSmsPermission)
     }
 
     @Test
     fun `toggleSmsReading shows rationale dialog when needed`() = runTest {
-        val preferences: IPreferencesManager = FakePreferencesManager()
-        val repository: IBudgetRepository = FakeBudgetRepository()
-        val permissions: IPermissionsManager = FakePermissionsManager()
-        permissions.hasSms = false
-        permissions.shouldShowRationale = true
+        val fakePreferences = FakePreferencesManager()
+        val fakeRepository = FakeBudgetRepository()
+        val fakePermissions = FakePermissionsManager()
+        fakePermissions.hasSms = false
+        fakePermissions.shouldShowRationale = true
 
-        val viewModel = SettingsViewModel(preferences, repository, permissions)
+        val viewModel = SettingsViewModel(fakePreferences, fakeRepository, fakePermissions)
 
         kotlinx.coroutines.delay(100)
         viewModel.sendEvent(SettingsEvent.ToggleSmsReading(true))
@@ -136,34 +136,34 @@ class SettingsViewModelTest {
 
     @Test
     fun `toggleAiProcessing updates preference`() = runTest {
-        val preferences: IPreferencesManager = FakePreferencesManager()
-        val repository: IBudgetRepository = FakeBudgetRepository()
-        val permissions: IPermissionsManager = FakePermissionsManager()
+        val fakePreferences = FakePreferencesManager()
+        val fakeRepository = FakeBudgetRepository()
+        val fakePermissions = FakePermissionsManager()
 
-        val viewModel = SettingsViewModel(preferences, repository, permissions)
+        val viewModel = SettingsViewModel(fakePreferences, fakeRepository, fakePermissions)
 
         kotlinx.coroutines.delay(100)
         viewModel.sendEvent(SettingsEvent.ToggleAiProcessing(true))
         kotlinx.coroutines.delay(100)
 
-        assertTrue(preferences.isAiProcessingEnabled())
+        assertTrue(fakePreferences.isAiProcessingEnabled())
         assertTrue(viewModel.uiState.value.isAiProcessingEnabled)
     }
 
     @Test
     fun `setDefaultBudget updates preference and state`() = runTest {
-        val preferences: IPreferencesManager = FakePreferencesManager()
-        val repository: IBudgetRepository = FakeBudgetRepository()
-        val permissions: IPermissionsManager = FakePermissionsManager()
+        val fakePreferences = FakePreferencesManager()
+        val fakeRepository = FakeBudgetRepository()
+        val fakePermissions = FakePermissionsManager()
 
-        val viewModel = SettingsViewModel(preferences, repository, permissions)
+        val viewModel = SettingsViewModel(fakePreferences, fakeRepository, fakePermissions)
 
         val budget = Budget(id = 5, name = "New Default", amount = 200.0)
         kotlinx.coroutines.delay(100)
         viewModel.sendEvent(SettingsEvent.SetDefaultBudget(budget))
         kotlinx.coroutines.delay(100)
 
-        assertEquals(5, preferences.getDefaultBudgetId())
+        assertEquals(5, fakePreferences.getDefaultBudgetId())
         assertEquals(budget, viewModel.uiState.value.defaultBudget)
         assertFalse(viewModel.uiState.value.isDefaultBudgetSelectorVisible)
     }
@@ -228,11 +228,11 @@ class SettingsViewModelTest {
 
     @Test
     fun `setSelectedBanks updates preferences and state`() = runTest {
-        val preferences: IPreferencesManager = FakePreferencesManager()
-        val repository: IBudgetRepository = FakeBudgetRepository()
-        val permissions: IPermissionsManager = FakePermissionsManager()
+        val fakePreferences = FakePreferencesManager()
+        val fakeRepository = FakeBudgetRepository()
+        val fakePermissions = FakePermissionsManager()
 
-        val viewModel = SettingsViewModel(preferences, repository, permissions)
+        val viewModel = SettingsViewModel(fakePreferences, fakeRepository, fakePermissions)
 
         val bankConfigs = setOf(
             BankSmsConfig(id = "bank1", displayName = "Bank 1", senderKeywords = emptyList<String>())
@@ -242,7 +242,7 @@ class SettingsViewModelTest {
         viewModel.sendEvent(SettingsEvent.SetSelectedBanks(bankConfigs))
         kotlinx.coroutines.delay(100)
 
-        assertEquals(setOf("bank1"), preferences.getSelectedBankIds())
+        assertEquals(setOf("bank1"), fakePreferences.getSelectedBankIds())
         assertEquals(bankConfigs, viewModel.uiState.value.selectedBanks)
     }
 
@@ -277,17 +277,17 @@ class SettingsViewModelTest {
 
     @Test
     fun `openAppSettings opens settings and hides dialog`() = runTest {
-        val preferences: IPreferencesManager = FakePreferencesManager()
-        val repository: IBudgetRepository = FakeBudgetRepository()
-        val permissions = FakePermissionsManager()
+        val fakePreferences = FakePreferencesManager()
+        val fakeRepository = FakeBudgetRepository()
+        val fakePermissions = FakePermissionsManager()
 
-        val viewModel = SettingsViewModel(preferences, repository, permissions)
+        val viewModel = SettingsViewModel(fakePreferences, fakeRepository, fakePermissions)
 
         kotlinx.coroutines.delay(100)
         viewModel.sendEvent(SettingsEvent.ShowManualPermissionDialog)
         viewModel.sendEvent(SettingsEvent.OpenAppSettings)
 
-        assertTrue(permissions.appSettingsOpened)
+        assertTrue(fakePermissions.appSettingsOpened)
         assertFalse(viewModel.uiState.value.isManualPermissionDialogVisible)
     }
 

--- a/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/settings/SettingsViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/settings/SettingsViewModelTest.kt
@@ -1,6 +1,9 @@
 package com.meneses.budgethunter.settings
 
+import com.meneses.budgethunter.budgetList.data.IBudgetRepository
 import com.meneses.budgethunter.budgetList.domain.Budget
+import com.meneses.budgethunter.commons.data.IPreferencesManager
+import com.meneses.budgethunter.commons.platform.IPermissionsManager
 import com.meneses.budgethunter.fakes.manager.FakePermissionsManager
 import com.meneses.budgethunter.fakes.manager.FakePreferencesManager
 import com.meneses.budgethunter.fakes.repository.FakeBudgetRepository

--- a/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/settings/SettingsViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/settings/SettingsViewModelTest.kt
@@ -235,7 +235,7 @@ class SettingsViewModelTest {
         val viewModel = SettingsViewModel(preferences, repository, permissions)
 
         val bankConfigs = setOf(
-            BankSmsConfig(id = "bank1", name = "Bank 1", senderIds = emptyList())
+            BankSmsConfig(id = "bank1", name = "Bank 1", senderIds = emptyList<String>())
         )
 
         kotlinx.coroutines.delay(100)

--- a/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/settings/SettingsViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/settings/SettingsViewModelTest.kt
@@ -1,0 +1,368 @@
+package com.meneses.budgethunter.settings
+
+import com.meneses.budgethunter.budgetList.data.BudgetRepository
+import com.meneses.budgethunter.budgetList.domain.Budget
+import com.meneses.budgethunter.commons.data.PreferencesManager
+import com.meneses.budgethunter.commons.platform.PermissionsManager
+import com.meneses.budgethunter.settings.application.SettingsEvent
+import com.meneses.budgethunter.sms.domain.BankSmsConfig
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class SettingsViewModelTest {
+
+    private class FakePreferencesManager : PreferencesManager {
+        private var smsReadingEnabled = false
+        private var aiProcessingEnabled = false
+        private var defaultBudgetId = -1
+        private var selectedBankIds = emptySet<String>()
+
+        override suspend fun isSmsReadingEnabled(): Boolean = smsReadingEnabled
+        override suspend fun setSmsReadingEnabled(enabled: Boolean) {
+            smsReadingEnabled = enabled
+        }
+
+        override suspend fun isAiProcessingEnabled(): Boolean = aiProcessingEnabled
+        override suspend fun setAiProcessingEnabled(enabled: Boolean) {
+            aiProcessingEnabled = enabled
+        }
+
+        override suspend fun getDefaultBudgetId(): Int = defaultBudgetId
+        override suspend fun setDefaultBudgetId(budgetId: Int) {
+            defaultBudgetId = budgetId
+        }
+
+        override suspend fun getSelectedBankIds(): Set<String> = selectedBankIds
+        override suspend fun setSelectedBankIds(bankIds: Set<String>) {
+            selectedBankIds = bankIds
+        }
+    }
+
+    private class FakeBudgetRepository : BudgetRepository {
+        private val budgetCache = mutableListOf<Budget>()
+        override val budgets: StateFlow<List<Budget>> = MutableStateFlow(emptyList())
+
+        fun setBudgets(budgets: List<Budget>) {
+            budgetCache.clear()
+            budgetCache.addAll(budgets)
+        }
+
+        override suspend fun create(budget: Budget): Budget = budget
+        override suspend fun update(budget: Budget) {}
+        override suspend fun getById(id: Int): Budget? = budgetCache.find { it.id == id }
+        override suspend fun getAllCached(): List<Budget> = budgetCache.toList()
+        override suspend fun getAllFilteredBy(filter: Any?): List<Budget> = budgetCache.toList()
+    }
+
+    private class FakePermissionsManager : PermissionsManager {
+        var hasSms = false
+        var shouldShowRationale = false
+        var appSettingsOpened = false
+        var permissionRequested = false
+        var grantPermission = false
+
+        override fun hasSmsPermission(): Boolean = hasSms
+        override fun shouldShowSMSPermissionRationale(): Boolean = shouldShowRationale
+        override fun requestSmsPermissions(onResult: (Boolean) -> Unit) {
+            permissionRequested = true
+            onResult(grantPermission)
+        }
+        override fun openAppSettings() {
+            appSettingsOpened = true
+        }
+    }
+
+    @Test
+    fun `initial state loads settings on initialization`() = runTest {
+        val preferences = FakePreferencesManager()
+        val repository = FakeBudgetRepository()
+        val permissions = FakePermissionsManager()
+
+        val viewModel = SettingsViewModel(preferences, repository, permissions)
+
+        kotlinx.coroutines.delay(100)
+
+        val state = viewModel.uiState.value
+        assertFalse(state.isLoading)
+    }
+
+    @Test
+    fun `loadSettings loads default budget`() = runTest {
+        val preferences = FakePreferencesManager()
+        preferences.setDefaultBudgetId(1)
+
+        val repository = FakeBudgetRepository()
+        val budget = Budget(id = 1, name = "Default Budget", amount = 100.0)
+        repository.setBudgets(listOf(budget))
+
+        val permissions = FakePermissionsManager()
+
+        val viewModel = SettingsViewModel(preferences, repository, permissions)
+
+        kotlinx.coroutines.delay(100)
+
+        val state = viewModel.uiState.value
+        assertEquals(budget, state.defaultBudget)
+    }
+
+    @Test
+    fun `loadSettings loads sms reading state`() = runTest {
+        val preferences = FakePreferencesManager()
+        preferences.setSmsReadingEnabled(true)
+
+        val repository = FakeBudgetRepository()
+        val permissions = FakePermissionsManager()
+
+        val viewModel = SettingsViewModel(preferences, repository, permissions)
+
+        kotlinx.coroutines.delay(100)
+
+        val state = viewModel.uiState.value
+        assertTrue(state.isSmsReadingEnabled)
+    }
+
+    @Test
+    fun `loadSettings loads ai processing state`() = runTest {
+        val preferences = FakePreferencesManager()
+        preferences.setAiProcessingEnabled(true)
+
+        val repository = FakeBudgetRepository()
+        val permissions = FakePermissionsManager()
+
+        val viewModel = SettingsViewModel(preferences, repository, permissions)
+
+        kotlinx.coroutines.delay(100)
+
+        val state = viewModel.uiState.value
+        assertTrue(state.isAiProcessingEnabled)
+    }
+
+    @Test
+    fun `toggleSmsReading enables sms reading`() = runTest {
+        val preferences = FakePreferencesManager()
+        val repository = FakeBudgetRepository()
+        val permissions = FakePermissionsManager()
+        permissions.hasSms = true
+
+        val viewModel = SettingsViewModel(preferences, repository, permissions)
+
+        kotlinx.coroutines.delay(100)
+        viewModel.sendEvent(SettingsEvent.ToggleSmsReading(true))
+        kotlinx.coroutines.delay(100)
+
+        assertTrue(preferences.isSmsReadingEnabled())
+        assertTrue(viewModel.uiState.value.isSmsReadingEnabled)
+    }
+
+    @Test
+    fun `toggleSmsReading requests permission when not granted`() = runTest {
+        val preferences = FakePreferencesManager()
+        val repository = FakeBudgetRepository()
+        val permissions = FakePermissionsManager()
+        permissions.hasSms = false
+        permissions.grantPermission = true
+
+        val viewModel = SettingsViewModel(preferences, repository, permissions)
+
+        kotlinx.coroutines.delay(100)
+        viewModel.sendEvent(SettingsEvent.ToggleSmsReading(true))
+        kotlinx.coroutines.delay(100)
+
+        assertTrue(permissions.permissionRequested)
+        assertTrue(viewModel.uiState.value.hasSmsPermission)
+    }
+
+    @Test
+    fun `toggleSmsReading shows rationale dialog when needed`() = runTest {
+        val preferences = FakePreferencesManager()
+        val repository = FakeBudgetRepository()
+        val permissions = FakePermissionsManager()
+        permissions.hasSms = false
+        permissions.shouldShowRationale = true
+
+        val viewModel = SettingsViewModel(preferences, repository, permissions)
+
+        kotlinx.coroutines.delay(100)
+        viewModel.sendEvent(SettingsEvent.ToggleSmsReading(true))
+        kotlinx.coroutines.delay(100)
+
+        assertTrue(viewModel.uiState.value.isManualPermissionDialogVisible)
+    }
+
+    @Test
+    fun `toggleAiProcessing updates preference`() = runTest {
+        val preferences = FakePreferencesManager()
+        val repository = FakeBudgetRepository()
+        val permissions = FakePermissionsManager()
+
+        val viewModel = SettingsViewModel(preferences, repository, permissions)
+
+        kotlinx.coroutines.delay(100)
+        viewModel.sendEvent(SettingsEvent.ToggleAiProcessing(true))
+        kotlinx.coroutines.delay(100)
+
+        assertTrue(preferences.isAiProcessingEnabled())
+        assertTrue(viewModel.uiState.value.isAiProcessingEnabled)
+    }
+
+    @Test
+    fun `setDefaultBudget updates preference and state`() = runTest {
+        val preferences = FakePreferencesManager()
+        val repository = FakeBudgetRepository()
+        val permissions = FakePermissionsManager()
+
+        val viewModel = SettingsViewModel(preferences, repository, permissions)
+
+        val budget = Budget(id = 5, name = "New Default", amount = 200.0)
+        kotlinx.coroutines.delay(100)
+        viewModel.sendEvent(SettingsEvent.SetDefaultBudget(budget))
+        kotlinx.coroutines.delay(100)
+
+        assertEquals(5, preferences.getDefaultBudgetId())
+        assertEquals(budget, viewModel.uiState.value.defaultBudget)
+        assertFalse(viewModel.uiState.value.isDefaultBudgetSelectorVisible)
+    }
+
+    @Test
+    fun `showDefaultBudgetSelector sets visibility`() = runTest {
+        val preferences = FakePreferencesManager()
+        val repository = FakeBudgetRepository()
+        val permissions = FakePermissionsManager()
+
+        val viewModel = SettingsViewModel(preferences, repository, permissions)
+
+        kotlinx.coroutines.delay(100)
+        viewModel.sendEvent(SettingsEvent.ShowDefaultBudgetSelector)
+
+        assertTrue(viewModel.uiState.value.isDefaultBudgetSelectorVisible)
+    }
+
+    @Test
+    fun `hideDefaultBudgetSelector sets visibility`() = runTest {
+        val preferences = FakePreferencesManager()
+        val repository = FakeBudgetRepository()
+        val permissions = FakePermissionsManager()
+
+        val viewModel = SettingsViewModel(preferences, repository, permissions)
+
+        kotlinx.coroutines.delay(100)
+        viewModel.sendEvent(SettingsEvent.ShowDefaultBudgetSelector)
+        viewModel.sendEvent(SettingsEvent.HideDefaultBudgetSelector)
+
+        assertFalse(viewModel.uiState.value.isDefaultBudgetSelectorVisible)
+    }
+
+    @Test
+    fun `showBankSelector sets visibility`() = runTest {
+        val preferences = FakePreferencesManager()
+        val repository = FakeBudgetRepository()
+        val permissions = FakePermissionsManager()
+
+        val viewModel = SettingsViewModel(preferences, repository, permissions)
+
+        kotlinx.coroutines.delay(100)
+        viewModel.sendEvent(SettingsEvent.ShowBankSelector)
+
+        assertTrue(viewModel.uiState.value.isBankSelectorVisible)
+    }
+
+    @Test
+    fun `hideBankSelector sets visibility`() = runTest {
+        val preferences = FakePreferencesManager()
+        val repository = FakeBudgetRepository()
+        val permissions = FakePermissionsManager()
+
+        val viewModel = SettingsViewModel(preferences, repository, permissions)
+
+        kotlinx.coroutines.delay(100)
+        viewModel.sendEvent(SettingsEvent.ShowBankSelector)
+        viewModel.sendEvent(SettingsEvent.HideBankSelector)
+
+        assertFalse(viewModel.uiState.value.isBankSelectorVisible)
+    }
+
+    @Test
+    fun `setSelectedBanks updates preferences and state`() = runTest {
+        val preferences = FakePreferencesManager()
+        val repository = FakeBudgetRepository()
+        val permissions = FakePermissionsManager()
+
+        val viewModel = SettingsViewModel(preferences, repository, permissions)
+
+        val bankConfigs = setOf(
+            BankSmsConfig(id = "bank1", name = "Bank 1", senderIds = emptyList())
+        )
+
+        kotlinx.coroutines.delay(100)
+        viewModel.sendEvent(SettingsEvent.SetSelectedBanks(bankConfigs))
+        kotlinx.coroutines.delay(100)
+
+        assertEquals(setOf("bank1"), preferences.getSelectedBankIds())
+        assertEquals(bankConfigs, viewModel.uiState.value.selectedBanks)
+    }
+
+    @Test
+    fun `showManualPermissionDialog sets visibility`() = runTest {
+        val preferences = FakePreferencesManager()
+        val repository = FakeBudgetRepository()
+        val permissions = FakePermissionsManager()
+
+        val viewModel = SettingsViewModel(preferences, repository, permissions)
+
+        kotlinx.coroutines.delay(100)
+        viewModel.sendEvent(SettingsEvent.ShowManualPermissionDialog)
+
+        assertTrue(viewModel.uiState.value.isManualPermissionDialogVisible)
+    }
+
+    @Test
+    fun `hideManualPermissionDialog sets visibility`() = runTest {
+        val preferences = FakePreferencesManager()
+        val repository = FakeBudgetRepository()
+        val permissions = FakePermissionsManager()
+
+        val viewModel = SettingsViewModel(preferences, repository, permissions)
+
+        kotlinx.coroutines.delay(100)
+        viewModel.sendEvent(SettingsEvent.ShowManualPermissionDialog)
+        viewModel.sendEvent(SettingsEvent.HideManualPermissionDialog)
+
+        assertFalse(viewModel.uiState.value.isManualPermissionDialogVisible)
+    }
+
+    @Test
+    fun `openAppSettings opens settings and hides dialog`() = runTest {
+        val preferences = FakePreferencesManager()
+        val repository = FakeBudgetRepository()
+        val permissions = FakePermissionsManager()
+
+        val viewModel = SettingsViewModel(preferences, repository, permissions)
+
+        kotlinx.coroutines.delay(100)
+        viewModel.sendEvent(SettingsEvent.ShowManualPermissionDialog)
+        viewModel.sendEvent(SettingsEvent.OpenAppSettings)
+
+        assertTrue(permissions.appSettingsOpened)
+        assertFalse(viewModel.uiState.value.isManualPermissionDialogVisible)
+    }
+
+    @Test
+    fun `loadSettings handles exception gracefully`() = runTest {
+        val preferences = FakePreferencesManager()
+        val repository = FakeBudgetRepository()
+        val permissions = FakePermissionsManager()
+
+        // This should not throw even if there are issues
+        val viewModel = SettingsViewModel(preferences, repository, permissions)
+
+        kotlinx.coroutines.delay(100)
+
+        // Should complete loading even with errors
+        assertFalse(viewModel.uiState.value.isLoading)
+    }
+}

--- a/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/settings/SettingsViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/settings/SettingsViewModelTest.kt
@@ -16,9 +16,9 @@ class SettingsViewModelTest {
 
     @Test
     fun `initial state loads settings on initialization`() = runTest {
-        val preferences = FakePreferencesManager()
-        val repository = FakeBudgetRepository()
-        val permissions = FakePermissionsManager()
+        val preferences: IPreferencesManager = FakePreferencesManager()
+        val repository: IBudgetRepository = FakeBudgetRepository()
+        val permissions: IPermissionsManager = FakePermissionsManager()
 
         val viewModel = SettingsViewModel(preferences, repository, permissions)
 
@@ -30,14 +30,14 @@ class SettingsViewModelTest {
 
     @Test
     fun `loadSettings loads default budget`() = runTest {
-        val preferences = FakePreferencesManager()
+        val preferences: IPreferencesManager = FakePreferencesManager()
         preferences.setDefaultBudgetId(1)
 
-        val repository = FakeBudgetRepository()
+        val repository: IBudgetRepository = FakeBudgetRepository()
         val budget = Budget(id = 1, name = "Default Budget", amount = 100.0)
         repository.setBudgets(listOf(budget))
 
-        val permissions = FakePermissionsManager()
+        val permissions: IPermissionsManager = FakePermissionsManager()
 
         val viewModel = SettingsViewModel(preferences, repository, permissions)
 
@@ -49,11 +49,11 @@ class SettingsViewModelTest {
 
     @Test
     fun `loadSettings loads sms reading state`() = runTest {
-        val preferences = FakePreferencesManager()
+        val preferences: IPreferencesManager = FakePreferencesManager()
         preferences.setSmsReadingEnabled(true)
 
-        val repository = FakeBudgetRepository()
-        val permissions = FakePermissionsManager()
+        val repository: IBudgetRepository = FakeBudgetRepository()
+        val permissions: IPermissionsManager = FakePermissionsManager()
 
         val viewModel = SettingsViewModel(preferences, repository, permissions)
 
@@ -65,11 +65,11 @@ class SettingsViewModelTest {
 
     @Test
     fun `loadSettings loads ai processing state`() = runTest {
-        val preferences = FakePreferencesManager()
+        val preferences: IPreferencesManager = FakePreferencesManager()
         preferences.setAiProcessingEnabled(true)
 
-        val repository = FakeBudgetRepository()
-        val permissions = FakePermissionsManager()
+        val repository: IBudgetRepository = FakeBudgetRepository()
+        val permissions: IPermissionsManager = FakePermissionsManager()
 
         val viewModel = SettingsViewModel(preferences, repository, permissions)
 
@@ -81,9 +81,9 @@ class SettingsViewModelTest {
 
     @Test
     fun `toggleSmsReading enables sms reading`() = runTest {
-        val preferences = FakePreferencesManager()
-        val repository = FakeBudgetRepository()
-        val permissions = FakePermissionsManager()
+        val preferences: IPreferencesManager = FakePreferencesManager()
+        val repository: IBudgetRepository = FakeBudgetRepository()
+        val permissions: IPermissionsManager = FakePermissionsManager()
         permissions.hasSms = true
 
         val viewModel = SettingsViewModel(preferences, repository, permissions)
@@ -98,9 +98,9 @@ class SettingsViewModelTest {
 
     @Test
     fun `toggleSmsReading requests permission when not granted`() = runTest {
-        val preferences = FakePreferencesManager()
-        val repository = FakeBudgetRepository()
-        val permissions = FakePermissionsManager()
+        val preferences: IPreferencesManager = FakePreferencesManager()
+        val repository: IBudgetRepository = FakeBudgetRepository()
+        val permissions: IPermissionsManager = FakePermissionsManager()
         permissions.hasSms = false
         permissions.grantPermission = true
 
@@ -116,9 +116,9 @@ class SettingsViewModelTest {
 
     @Test
     fun `toggleSmsReading shows rationale dialog when needed`() = runTest {
-        val preferences = FakePreferencesManager()
-        val repository = FakeBudgetRepository()
-        val permissions = FakePermissionsManager()
+        val preferences: IPreferencesManager = FakePreferencesManager()
+        val repository: IBudgetRepository = FakeBudgetRepository()
+        val permissions: IPermissionsManager = FakePermissionsManager()
         permissions.hasSms = false
         permissions.shouldShowRationale = true
 
@@ -133,9 +133,9 @@ class SettingsViewModelTest {
 
     @Test
     fun `toggleAiProcessing updates preference`() = runTest {
-        val preferences = FakePreferencesManager()
-        val repository = FakeBudgetRepository()
-        val permissions = FakePermissionsManager()
+        val preferences: IPreferencesManager = FakePreferencesManager()
+        val repository: IBudgetRepository = FakeBudgetRepository()
+        val permissions: IPermissionsManager = FakePermissionsManager()
 
         val viewModel = SettingsViewModel(preferences, repository, permissions)
 
@@ -149,9 +149,9 @@ class SettingsViewModelTest {
 
     @Test
     fun `setDefaultBudget updates preference and state`() = runTest {
-        val preferences = FakePreferencesManager()
-        val repository = FakeBudgetRepository()
-        val permissions = FakePermissionsManager()
+        val preferences: IPreferencesManager = FakePreferencesManager()
+        val repository: IBudgetRepository = FakeBudgetRepository()
+        val permissions: IPermissionsManager = FakePermissionsManager()
 
         val viewModel = SettingsViewModel(preferences, repository, permissions)
 
@@ -167,9 +167,9 @@ class SettingsViewModelTest {
 
     @Test
     fun `showDefaultBudgetSelector sets visibility`() = runTest {
-        val preferences = FakePreferencesManager()
-        val repository = FakeBudgetRepository()
-        val permissions = FakePermissionsManager()
+        val preferences: IPreferencesManager = FakePreferencesManager()
+        val repository: IBudgetRepository = FakeBudgetRepository()
+        val permissions: IPermissionsManager = FakePermissionsManager()
 
         val viewModel = SettingsViewModel(preferences, repository, permissions)
 
@@ -181,9 +181,9 @@ class SettingsViewModelTest {
 
     @Test
     fun `hideDefaultBudgetSelector sets visibility`() = runTest {
-        val preferences = FakePreferencesManager()
-        val repository = FakeBudgetRepository()
-        val permissions = FakePermissionsManager()
+        val preferences: IPreferencesManager = FakePreferencesManager()
+        val repository: IBudgetRepository = FakeBudgetRepository()
+        val permissions: IPermissionsManager = FakePermissionsManager()
 
         val viewModel = SettingsViewModel(preferences, repository, permissions)
 
@@ -196,9 +196,9 @@ class SettingsViewModelTest {
 
     @Test
     fun `showBankSelector sets visibility`() = runTest {
-        val preferences = FakePreferencesManager()
-        val repository = FakeBudgetRepository()
-        val permissions = FakePermissionsManager()
+        val preferences: IPreferencesManager = FakePreferencesManager()
+        val repository: IBudgetRepository = FakeBudgetRepository()
+        val permissions: IPermissionsManager = FakePermissionsManager()
 
         val viewModel = SettingsViewModel(preferences, repository, permissions)
 
@@ -210,9 +210,9 @@ class SettingsViewModelTest {
 
     @Test
     fun `hideBankSelector sets visibility`() = runTest {
-        val preferences = FakePreferencesManager()
-        val repository = FakeBudgetRepository()
-        val permissions = FakePermissionsManager()
+        val preferences: IPreferencesManager = FakePreferencesManager()
+        val repository: IBudgetRepository = FakeBudgetRepository()
+        val permissions: IPermissionsManager = FakePermissionsManager()
 
         val viewModel = SettingsViewModel(preferences, repository, permissions)
 
@@ -225,9 +225,9 @@ class SettingsViewModelTest {
 
     @Test
     fun `setSelectedBanks updates preferences and state`() = runTest {
-        val preferences = FakePreferencesManager()
-        val repository = FakeBudgetRepository()
-        val permissions = FakePermissionsManager()
+        val preferences: IPreferencesManager = FakePreferencesManager()
+        val repository: IBudgetRepository = FakeBudgetRepository()
+        val permissions: IPermissionsManager = FakePermissionsManager()
 
         val viewModel = SettingsViewModel(preferences, repository, permissions)
 
@@ -245,9 +245,9 @@ class SettingsViewModelTest {
 
     @Test
     fun `showManualPermissionDialog sets visibility`() = runTest {
-        val preferences = FakePreferencesManager()
-        val repository = FakeBudgetRepository()
-        val permissions = FakePermissionsManager()
+        val preferences: IPreferencesManager = FakePreferencesManager()
+        val repository: IBudgetRepository = FakeBudgetRepository()
+        val permissions: IPermissionsManager = FakePermissionsManager()
 
         val viewModel = SettingsViewModel(preferences, repository, permissions)
 
@@ -259,9 +259,9 @@ class SettingsViewModelTest {
 
     @Test
     fun `hideManualPermissionDialog sets visibility`() = runTest {
-        val preferences = FakePreferencesManager()
-        val repository = FakeBudgetRepository()
-        val permissions = FakePermissionsManager()
+        val preferences: IPreferencesManager = FakePreferencesManager()
+        val repository: IBudgetRepository = FakeBudgetRepository()
+        val permissions: IPermissionsManager = FakePermissionsManager()
 
         val viewModel = SettingsViewModel(preferences, repository, permissions)
 
@@ -274,9 +274,9 @@ class SettingsViewModelTest {
 
     @Test
     fun `openAppSettings opens settings and hides dialog`() = runTest {
-        val preferences = FakePreferencesManager()
-        val repository = FakeBudgetRepository()
-        val permissions = FakePermissionsManager()
+        val preferences: IPreferencesManager = FakePreferencesManager()
+        val repository: IBudgetRepository = FakeBudgetRepository()
+        val permissions: IPermissionsManager = FakePermissionsManager()
 
         val viewModel = SettingsViewModel(preferences, repository, permissions)
 
@@ -290,9 +290,9 @@ class SettingsViewModelTest {
 
     @Test
     fun `loadSettings handles exception gracefully`() = runTest {
-        val preferences = FakePreferencesManager()
-        val repository = FakeBudgetRepository()
-        val permissions = FakePermissionsManager()
+        val preferences: IPreferencesManager = FakePreferencesManager()
+        val repository: IBudgetRepository = FakeBudgetRepository()
+        val permissions: IPermissionsManager = FakePermissionsManager()
 
         // This should not throw even if there are issues
         val viewModel = SettingsViewModel(preferences, repository, permissions)

--- a/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/settings/SettingsViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/settings/SettingsViewModelTest.kt
@@ -279,7 +279,7 @@ class SettingsViewModelTest {
     fun `openAppSettings opens settings and hides dialog`() = runTest {
         val preferences: IPreferencesManager = FakePreferencesManager()
         val repository: IBudgetRepository = FakeBudgetRepository()
-        val permissions: IPermissionsManager = FakePermissionsManager()
+        val permissions = FakePermissionsManager()
 
         val viewModel = SettingsViewModel(preferences, repository, permissions)
 

--- a/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/settings/SettingsViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/settings/SettingsViewModelTest.kt
@@ -235,7 +235,7 @@ class SettingsViewModelTest {
         val viewModel = SettingsViewModel(preferences, repository, permissions)
 
         val bankConfigs = setOf(
-            BankSmsConfig(id = "bank1", name = "Bank 1", senderIds = emptyList<String>())
+            BankSmsConfig(id = "bank1", displayName = "Bank 1", senderKeywords = emptyList<String>())
         )
 
         kotlinx.coroutines.delay(100)

--- a/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/splash/SplashScreenViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/splash/SplashScreenViewModelTest.kt
@@ -1,35 +1,15 @@
 package com.meneses.budgethunter.splash
 
-import com.meneses.budgethunter.commons.platform.AppUpdateManager
 import com.meneses.budgethunter.commons.platform.AppUpdateResult
+import com.meneses.budgethunter.fakes.manager.FakeAppUpdateManager
+import com.meneses.budgethunter.fakes.manager.FakeAppUpdateResult
 import com.meneses.budgethunter.splash.application.SplashEvent
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
-import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class SplashScreenViewModelTest {
-
-    private class FakeAppUpdateManager(
-        private val updateResult: AppUpdateResult
-    ) : AppUpdateManager {
-        var checkForUpdatesCalled = false
-        var startUpdateCalled = false
-
-        override fun checkForUpdates(callback: (AppUpdateResult) -> Unit) {
-            checkForUpdatesCalled = true
-            callback(updateResult)
-        }
-    }
-
-    private class FakeAppUpdateResult(
-        private val onStart: () -> Unit = {}
-    ) : AppUpdateResult.UpdateAvailable {
-        override fun startUpdate() {
-            onStart()
-        }
-    }
 
     @Test
     fun `initial state has navigate and updatingApp false`() = runTest {

--- a/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/splash/SplashScreenViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/splash/SplashScreenViewModelTest.kt
@@ -1,0 +1,130 @@
+package com.meneses.budgethunter.splash
+
+import com.meneses.budgethunter.commons.platform.AppUpdateManager
+import com.meneses.budgethunter.commons.platform.AppUpdateResult
+import com.meneses.budgethunter.splash.application.SplashEvent
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class SplashScreenViewModelTest {
+
+    private class FakeAppUpdateManager(
+        private val updateResult: AppUpdateResult
+    ) : AppUpdateManager {
+        var checkForUpdatesCalled = false
+        var startUpdateCalled = false
+
+        override fun checkForUpdates(callback: (AppUpdateResult) -> Unit) {
+            checkForUpdatesCalled = true
+            callback(updateResult)
+        }
+    }
+
+    private class FakeAppUpdateResult(
+        private val onStart: () -> Unit = {}
+    ) : AppUpdateResult.UpdateAvailable {
+        override fun startUpdate() {
+            onStart()
+        }
+    }
+
+    @Test
+    fun `initial state has navigate and updatingApp false`() = runTest {
+        val fakeManager = FakeAppUpdateManager(AppUpdateResult.NoUpdateAvailable)
+        val viewModel = SplashScreenViewModel(fakeManager)
+
+        val state = viewModel.uiState.value
+        assertFalse(state.navigate)
+        assertFalse(state.updatingApp)
+    }
+
+    @Test
+    fun `verifyUpdate calls checkForUpdates on app update manager`() = runTest {
+        val fakeManager = FakeAppUpdateManager(AppUpdateResult.NoUpdateAvailable)
+        val viewModel = SplashScreenViewModel(fakeManager)
+
+        viewModel.sendEvent(SplashEvent.VerifyUpdate)
+
+        assertTrue(fakeManager.checkForUpdatesCalled)
+    }
+
+    @Test
+    fun `verifyUpdate sets navigate to true when no update available`() = runTest {
+        val fakeManager = FakeAppUpdateManager(AppUpdateResult.NoUpdateAvailable)
+        val viewModel = SplashScreenViewModel(fakeManager)
+
+        viewModel.sendEvent(SplashEvent.VerifyUpdate)
+
+        val state = viewModel.uiState.value
+        assertTrue(state.navigate)
+        assertFalse(state.updatingApp)
+    }
+
+    @Test
+    fun `verifyUpdate sets updatingApp to true when update in progress`() = runTest {
+        val fakeManager = FakeAppUpdateManager(AppUpdateResult.UpdateInProgress)
+        val viewModel = SplashScreenViewModel(fakeManager)
+
+        viewModel.sendEvent(SplashEvent.VerifyUpdate)
+
+        val state = viewModel.uiState.value
+        assertFalse(state.navigate)
+        assertTrue(state.updatingApp)
+    }
+
+    @Test
+    fun `verifyUpdate calls startUpdate when update available`() = runTest {
+        var startUpdateCalled = false
+        val updateResult = FakeAppUpdateResult { startUpdateCalled = true }
+        val fakeManager = FakeAppUpdateManager(updateResult)
+        val viewModel = SplashScreenViewModel(fakeManager)
+
+        viewModel.sendEvent(SplashEvent.VerifyUpdate)
+
+        assertTrue(startUpdateCalled)
+        val state = viewModel.uiState.value
+        assertFalse(state.navigate)
+        assertFalse(state.updatingApp)
+    }
+
+    @Test
+    fun `verifyUpdate sets navigate to true when update failed`() = runTest {
+        val fakeManager = FakeAppUpdateManager(AppUpdateResult.UpdateFailed)
+        val viewModel = SplashScreenViewModel(fakeManager)
+
+        viewModel.sendEvent(SplashEvent.VerifyUpdate)
+
+        val state = viewModel.uiState.value
+        assertTrue(state.navigate)
+        assertFalse(state.updatingApp)
+    }
+
+    @Test
+    fun `verifyUpdate can be called multiple times`() = runTest {
+        val fakeManager = FakeAppUpdateManager(AppUpdateResult.NoUpdateAvailable)
+        val viewModel = SplashScreenViewModel(fakeManager)
+
+        viewModel.sendEvent(SplashEvent.VerifyUpdate)
+        viewModel.sendEvent(SplashEvent.VerifyUpdate)
+
+        assertTrue(fakeManager.checkForUpdatesCalled)
+    }
+
+    @Test
+    fun `state changes are reflected in uiState flow`() = runTest {
+        val fakeManager = FakeAppUpdateManager(AppUpdateResult.UpdateInProgress)
+        val viewModel = SplashScreenViewModel(fakeManager)
+
+        val initialState = viewModel.uiState.value
+        assertFalse(initialState.navigate)
+        assertFalse(initialState.updatingApp)
+
+        viewModel.sendEvent(SplashEvent.VerifyUpdate)
+
+        val updatedState = viewModel.uiState.value
+        assertTrue(updatedState.updatingApp)
+    }
+}

--- a/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/splash/SplashScreenViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/splash/SplashScreenViewModelTest.kt
@@ -1,6 +1,7 @@
 package com.meneses.budgethunter.splash
 
 import com.meneses.budgethunter.commons.platform.AppUpdateResult
+import com.meneses.budgethunter.commons.platform.IAppUpdateManager
 import com.meneses.budgethunter.fakes.manager.FakeAppUpdateManager
 import com.meneses.budgethunter.fakes.manager.FakeAppUpdateResult
 import com.meneses.budgethunter.splash.application.SplashEvent

--- a/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/splash/SplashScreenViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/splash/SplashScreenViewModelTest.kt
@@ -24,7 +24,7 @@ class SplashScreenViewModelTest {
 
     @Test
     fun `verifyUpdate calls checkForUpdates on app update manager`() = runTest {
-        val fakeManager: IAppUpdateManager = FakeAppUpdateManager(AppUpdateResult.NoUpdateAvailable)
+        val fakeManager = FakeAppUpdateManager(AppUpdateResult.NoUpdateAvailable)
         val viewModel = SplashScreenViewModel(fakeManager)
 
         viewModel.sendEvent(SplashEvent.VerifyUpdate)
@@ -85,7 +85,7 @@ class SplashScreenViewModelTest {
 
     @Test
     fun `verifyUpdate can be called multiple times`() = runTest {
-        val fakeManager: IAppUpdateManager = FakeAppUpdateManager(AppUpdateResult.NoUpdateAvailable)
+        val fakeManager = FakeAppUpdateManager(AppUpdateResult.NoUpdateAvailable)
         val viewModel = SplashScreenViewModel(fakeManager)
 
         viewModel.sendEvent(SplashEvent.VerifyUpdate)

--- a/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/splash/SplashScreenViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/meneses/budgethunter/splash/SplashScreenViewModelTest.kt
@@ -13,7 +13,7 @@ class SplashScreenViewModelTest {
 
     @Test
     fun `initial state has navigate and updatingApp false`() = runTest {
-        val fakeManager = FakeAppUpdateManager(AppUpdateResult.NoUpdateAvailable)
+        val fakeManager: IAppUpdateManager = FakeAppUpdateManager(AppUpdateResult.NoUpdateAvailable)
         val viewModel = SplashScreenViewModel(fakeManager)
 
         val state = viewModel.uiState.value
@@ -23,7 +23,7 @@ class SplashScreenViewModelTest {
 
     @Test
     fun `verifyUpdate calls checkForUpdates on app update manager`() = runTest {
-        val fakeManager = FakeAppUpdateManager(AppUpdateResult.NoUpdateAvailable)
+        val fakeManager: IAppUpdateManager = FakeAppUpdateManager(AppUpdateResult.NoUpdateAvailable)
         val viewModel = SplashScreenViewModel(fakeManager)
 
         viewModel.sendEvent(SplashEvent.VerifyUpdate)
@@ -33,7 +33,7 @@ class SplashScreenViewModelTest {
 
     @Test
     fun `verifyUpdate sets navigate to true when no update available`() = runTest {
-        val fakeManager = FakeAppUpdateManager(AppUpdateResult.NoUpdateAvailable)
+        val fakeManager: IAppUpdateManager = FakeAppUpdateManager(AppUpdateResult.NoUpdateAvailable)
         val viewModel = SplashScreenViewModel(fakeManager)
 
         viewModel.sendEvent(SplashEvent.VerifyUpdate)
@@ -45,7 +45,7 @@ class SplashScreenViewModelTest {
 
     @Test
     fun `verifyUpdate sets updatingApp to true when update in progress`() = runTest {
-        val fakeManager = FakeAppUpdateManager(AppUpdateResult.UpdateInProgress)
+        val fakeManager: IAppUpdateManager = FakeAppUpdateManager(AppUpdateResult.UpdateInProgress)
         val viewModel = SplashScreenViewModel(fakeManager)
 
         viewModel.sendEvent(SplashEvent.VerifyUpdate)
@@ -59,7 +59,7 @@ class SplashScreenViewModelTest {
     fun `verifyUpdate calls startUpdate when update available`() = runTest {
         var startUpdateCalled = false
         val updateResult = FakeAppUpdateResult { startUpdateCalled = true }
-        val fakeManager = FakeAppUpdateManager(updateResult)
+        val fakeManager: IAppUpdateManager = FakeAppUpdateManager(updateResult)
         val viewModel = SplashScreenViewModel(fakeManager)
 
         viewModel.sendEvent(SplashEvent.VerifyUpdate)
@@ -72,7 +72,7 @@ class SplashScreenViewModelTest {
 
     @Test
     fun `verifyUpdate sets navigate to true when update failed`() = runTest {
-        val fakeManager = FakeAppUpdateManager(AppUpdateResult.UpdateFailed)
+        val fakeManager: IAppUpdateManager = FakeAppUpdateManager(AppUpdateResult.UpdateFailed)
         val viewModel = SplashScreenViewModel(fakeManager)
 
         viewModel.sendEvent(SplashEvent.VerifyUpdate)
@@ -84,7 +84,7 @@ class SplashScreenViewModelTest {
 
     @Test
     fun `verifyUpdate can be called multiple times`() = runTest {
-        val fakeManager = FakeAppUpdateManager(AppUpdateResult.NoUpdateAvailable)
+        val fakeManager: IAppUpdateManager = FakeAppUpdateManager(AppUpdateResult.NoUpdateAvailable)
         val viewModel = SplashScreenViewModel(fakeManager)
 
         viewModel.sendEvent(SplashEvent.VerifyUpdate)
@@ -95,7 +95,7 @@ class SplashScreenViewModelTest {
 
     @Test
     fun `state changes are reflected in uiState flow`() = runTest {
-        val fakeManager = FakeAppUpdateManager(AppUpdateResult.UpdateInProgress)
+        val fakeManager: IAppUpdateManager = FakeAppUpdateManager(AppUpdateResult.UpdateInProgress)
         val viewModel = SplashScreenViewModel(fakeManager)
 
         val initialState = viewModel.uiState.value

--- a/composeApp/src/iosMain/kotlin/com/meneses/budgethunter/commons/data/FileManager.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/meneses/budgethunter/commons/data/FileManager.ios.kt
@@ -20,9 +20,9 @@ import platform.Foundation.create
  * iOS implementation of FileManager for budget entry invoice handling.
  */
 @OptIn(ExperimentalForeignApi::class)
-actual class FileManager {
+actual class FileManager : IFileManager {
 
-    actual fun saveFile(fileData: FileData): String {
+    override fun saveFile(fileData: FileData): String {
         val targetDirectory = if (fileData.directory.isNotEmpty()) {
             fileData.directory
         } else {
@@ -48,7 +48,7 @@ actual class FileManager {
         }
     }
 
-    actual fun deleteFile(filePath: String): Boolean {
+    override fun deleteFile(filePath: String): Boolean {
         return try {
             println("FileManager.deleteFile: Attempting to delete $filePath")
 
@@ -78,14 +78,14 @@ actual class FileManager {
         }
     }
 
-    actual fun createUri(filePath: String): String {
+    override fun createUri(filePath: String): String {
         return "file://$filePath"
     }
 
     /**
      * Validates if a file exists and is accessible
      */
-    actual fun fileExists(filePath: String): Boolean {
+    override fun fileExists(filePath: String): Boolean {
         val cleanPath = if (filePath.startsWith("file://")) {
             filePath.removePrefix("file://")
         } else {

--- a/composeApp/src/iosMain/kotlin/com/meneses/budgethunter/commons/platform/AppUpdateManager.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/meneses/budgethunter/commons/platform/AppUpdateManager.ios.kt
@@ -27,7 +27,7 @@ private data class AppStoreResult(
     val releaseNotes: String? = null
 )
 
-actual class AppUpdateManager : IAppUpdateManager {
+class AppUpdateManager : IAppUpdateManager {
 
     private val scope = CoroutineScope(Dispatchers.Default)
     private val httpClient = HttpClient(Darwin)

--- a/composeApp/src/iosMain/kotlin/com/meneses/budgethunter/commons/platform/AppUpdateManager.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/meneses/budgethunter/commons/platform/AppUpdateManager.ios.kt
@@ -27,7 +27,7 @@ private data class AppStoreResult(
     val releaseNotes: String? = null
 )
 
-actual class AppUpdateManager {
+actual class AppUpdateManager : IAppUpdateManager {
 
     private val scope = CoroutineScope(Dispatchers.Default)
     private val httpClient = HttpClient(Darwin)
@@ -36,7 +36,7 @@ actual class AppUpdateManager {
         isLenient = true
     }
 
-    actual fun checkForUpdates(onResult: (AppUpdateResult) -> Unit) {
+    override fun checkForUpdates(onResult: (AppUpdateResult) -> Unit) {
         scope.launch {
             try {
                 val bundleId = getBundleId()

--- a/composeApp/src/iosMain/kotlin/com/meneses/budgethunter/commons/platform/AppUpdateManager.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/meneses/budgethunter/commons/platform/AppUpdateManager.ios.kt
@@ -27,7 +27,7 @@ private data class AppStoreResult(
     val releaseNotes: String? = null
 )
 
-class AppUpdateManager : IAppUpdateManager {
+actual class AppUpdateManager : IAppUpdateManager {
 
     private val scope = CoroutineScope(Dispatchers.Default)
     private val httpClient = HttpClient(Darwin)

--- a/composeApp/src/iosMain/kotlin/com/meneses/budgethunter/commons/platform/PermissionsManager.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/meneses/budgethunter/commons/platform/PermissionsManager.ios.kt
@@ -1,6 +1,6 @@
 package com.meneses.budgethunter.commons.platform
 
-class PermissionsManager : IPermissionsManager {
+actual class PermissionsManager : IPermissionsManager {
 
     override fun shouldShowSMSPermissionRationale(): Boolean {
         // iOS doesn't have SMS permissions like Android

--- a/composeApp/src/iosMain/kotlin/com/meneses/budgethunter/commons/platform/PermissionsManager.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/meneses/budgethunter/commons/platform/PermissionsManager.ios.kt
@@ -1,6 +1,6 @@
 package com.meneses.budgethunter.commons.platform
 
-actual class PermissionsManager : IPermissionsManager {
+class PermissionsManager : IPermissionsManager {
 
     override fun shouldShowSMSPermissionRationale(): Boolean {
         // iOS doesn't have SMS permissions like Android

--- a/composeApp/src/iosMain/kotlin/com/meneses/budgethunter/commons/platform/PermissionsManager.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/meneses/budgethunter/commons/platform/PermissionsManager.ios.kt
@@ -1,26 +1,26 @@
 package com.meneses.budgethunter.commons.platform
 
-actual class PermissionsManager {
+actual class PermissionsManager : IPermissionsManager {
 
-    actual fun shouldShowSMSPermissionRationale(): Boolean {
+    override fun shouldShowSMSPermissionRationale(): Boolean {
         // iOS doesn't have SMS permissions like Android
         return false
     }
 
-    actual fun hasSmsPermission(): Boolean {
+    override fun hasSmsPermission(): Boolean {
         // iOS doesn't have SMS reading capabilities like Android
         // This feature would need to be handled differently on iOS
         return false
     }
 
-    actual fun requestSmsPermissions(callback: (granted: Boolean) -> Unit) {
+    override fun requestSmsPermissions(callback: (granted: Boolean) -> Unit) {
         // iOS doesn't support SMS reading like Android
         // On iOS, this would need alternative implementation
         println("PermissionsManager.requestSmsPermissions() called - iOS doesn't support SMS reading")
         callback(false)
     }
 
-    actual fun openAppSettings() {
+    override fun openAppSettings() {
         // iOS implementation placeholder
         // This would open iOS Settings app using UIApplication.shared.open
         println("PermissionsManager.openAppSettings() called - iOS implementation needed")

--- a/composeApp/src/iosMain/kotlin/com/meneses/budgethunter/di/PlatformModule.kt
+++ b/composeApp/src/iosMain/kotlin/com/meneses/budgethunter/di/PlatformModule.kt
@@ -28,7 +28,6 @@ import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.serialization.json.Json
 import okio.Path.Companion.toPath
-import org.koin.core.module.dsl.bind
 import org.koin.core.qualifier.named
 import org.koin.dsl.module
 import platform.Foundation.NSBundle
@@ -64,11 +63,18 @@ val iosPlatformModule = module {
     }
 
     // Platform-specific managers
-    single<FileManager> { FileManager() } bind IFileManager::class
+    single<FileManager> { FileManager() }
+    single<IFileManager> { get<FileManager>() }
+
     single<CameraManager> { IOSBridge.cameraManager }
     single<FilePickerManager> { IOSBridge.filePickerManager }
-    single<PermissionsManager> { PermissionsManager() } bind IPermissionsManager::class
-    single<AppUpdateManager> { AppUpdateManager() } bind IAppUpdateManager::class
+
+    single<PermissionsManager> { PermissionsManager() }
+    single<IPermissionsManager> { get<PermissionsManager>() }
+
+    single<AppUpdateManager> { AppUpdateManager() }
+    single<IAppUpdateManager> { get<AppUpdateManager>() }
+
     single<NotificationManager> { IOSBridge.notificationManager }
     single<ShareManager> { IOSBridge.shareManager }
 

--- a/composeApp/src/iosMain/kotlin/com/meneses/budgethunter/di/PlatformModule.kt
+++ b/composeApp/src/iosMain/kotlin/com/meneses/budgethunter/di/PlatformModule.kt
@@ -28,6 +28,7 @@ import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.serialization.json.Json
 import okio.Path.Companion.toPath
+import org.koin.core.module.dsl.bind
 import org.koin.core.qualifier.named
 import org.koin.dsl.module
 import platform.Foundation.NSBundle

--- a/composeApp/src/iosMain/kotlin/com/meneses/budgethunter/di/PlatformModule.kt
+++ b/composeApp/src/iosMain/kotlin/com/meneses/budgethunter/di/PlatformModule.kt
@@ -9,8 +9,11 @@ import com.meneses.budgethunter.budgetEntry.domain.AIImageProcessor
 import com.meneses.budgethunter.budgetEntry.domain.IosAIImageProcessor
 import com.meneses.budgethunter.commons.data.DatabaseFactory
 import com.meneses.budgethunter.commons.data.FileManager
+import com.meneses.budgethunter.commons.data.IFileManager
 import com.meneses.budgethunter.commons.data.createDatabase
 import com.meneses.budgethunter.commons.platform.AppUpdateManager
+import com.meneses.budgethunter.commons.platform.IAppUpdateManager
+import com.meneses.budgethunter.commons.platform.IPermissionsManager
 import com.meneses.budgethunter.commons.platform.CameraManager
 import com.meneses.budgethunter.commons.platform.FilePickerManager
 import com.meneses.budgethunter.commons.platform.NotificationManager
@@ -60,11 +63,11 @@ val iosPlatformModule = module {
     }
 
     // Platform-specific managers
-    single<FileManager> { FileManager() }
+    single<FileManager> { FileManager() } bind IFileManager::class
     single<CameraManager> { IOSBridge.cameraManager }
     single<FilePickerManager> { IOSBridge.filePickerManager }
-    single<PermissionsManager> { PermissionsManager() }
-    single<AppUpdateManager> { AppUpdateManager() }
+    single<PermissionsManager> { PermissionsManager() } bind IPermissionsManager::class
+    single<AppUpdateManager> { AppUpdateManager() } bind IAppUpdateManager::class
     single<NotificationManager> { IOSBridge.notificationManager }
     single<ShareManager> { IOSBridge.shareManager }
 


### PR DESCRIPTION
## Summary
- Add BudgetEntryViewModelTest with 44 tests covering file management, AI processing, and state management
- Add BudgetDetailViewModelTest with 25 tests for budget detail operations, filtering, and sorting
- Add BudgetListViewModelTest with 20 tests for budget CRUD operations and search functionality
- Add BudgetMetricsViewModelTest with 9 tests for metrics calculations and percentages
- Add SettingsViewModelTest with 22 tests for settings, permissions, and preferences
- Add SplashScreenViewModelTest with 8 tests for app update handling

Total: 128 comprehensive unit tests covering all 6 ViewModels

Resolves #19

🤖 Generated with [Claude Code](https://claude.ai/code)